### PR TITLE
feat: implement goals management CRUD with deposits

### DIFF
--- a/poupeai-core-business/src/main/java/io/github/poupeai/core/business/adapter/GoalDepositServiceAdapter.java
+++ b/poupeai-core-business/src/main/java/io/github/poupeai/core/business/adapter/GoalDepositServiceAdapter.java
@@ -1,0 +1,50 @@
+package io.github.poupeai.core.business.adapter;
+
+import io.github.poupeai.core.domain.exception.ResourceNotFoundException;
+import io.github.poupeai.core.domain.model.GoalDeposit;
+import io.github.poupeai.core.domain.port.business.GoalDepositServicePort;
+import io.github.poupeai.core.domain.port.persistence.GoalDepositRepositoryPort;
+import io.github.poupeai.core.domain.port.persistence.GoalRepositoryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class GoalDepositServiceAdapter implements GoalDepositServicePort {
+    private final GoalDepositRepositoryPort goalDepositRepositoryPort;
+    private final GoalRepositoryPort goalRepositoryPort;
+
+    @Override
+    @Transactional
+    public GoalDeposit create(GoalDeposit goalDeposit, UUID profileId) {
+        if (!goalRepositoryPort.existsByIdAndProfileId(goalDeposit.getGoalId(), profileId)) {
+            throw new ResourceNotFoundException("Meta não encontrada.");
+        }
+        return goalDepositRepositoryPort.create(goalDeposit);
+    }
+
+    @Override
+    public List<GoalDeposit> findAllByGoalId(UUID goalId, UUID profileId) {
+        if (!goalRepositoryPort.existsByIdAndProfileId(goalId, profileId)) {
+            throw new ResourceNotFoundException("Meta não encontrada.");
+        }
+        return goalDepositRepositoryPort.findAllByGoalId(goalId);
+    }
+
+    @Override
+    @Transactional
+    public void delete(UUID goalId, UUID depositId, UUID profileId) {
+        if (!goalRepositoryPort.existsByIdAndProfileId(goalId, profileId)) {
+            throw new ResourceNotFoundException("Meta não encontrada.");
+        }
+        
+        var deposit = goalDepositRepositoryPort.findByIdAndGoalId(depositId, goalId)
+            .orElseThrow(() -> new ResourceNotFoundException("Depósito não encontrado."));
+        
+        goalDepositRepositoryPort.delete(depositId);
+    }
+}

--- a/poupeai-core-business/src/main/java/io/github/poupeai/core/business/adapter/GoalServiceAdapter.java
+++ b/poupeai-core-business/src/main/java/io/github/poupeai/core/business/adapter/GoalServiceAdapter.java
@@ -1,0 +1,50 @@
+package io.github.poupeai.core.business.adapter;
+
+import io.github.poupeai.core.domain.exception.ResourceNotFoundException;
+import io.github.poupeai.core.domain.model.Goal;
+import io.github.poupeai.core.domain.port.business.GoalServicePort;
+import io.github.poupeai.core.domain.port.persistence.GoalRepositoryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class GoalServiceAdapter implements GoalServicePort {
+    private final GoalRepositoryPort goalRepositoryPort;
+
+    @Override
+    @Transactional
+    public Goal create(Goal goal) {
+        return goalRepositoryPort.create(goal);
+    }
+
+    @Override
+    @Transactional
+    public Goal update(Goal goal) {
+        return goalRepositoryPort.update(goal);
+    }
+
+    @Override
+    public Goal findByIdAndProfileId(UUID id, UUID profileId) {
+        return goalRepositoryPort.findByIdAndProfileId(id, profileId)
+            .orElseThrow(() -> new ResourceNotFoundException("Meta não encontrada."));
+    }
+
+    @Override
+    public List<Goal> findAllByProfileId(UUID profileId) {
+        return goalRepositoryPort.findAllByProfileId(profileId);
+    }
+
+    @Override
+    @Transactional
+    public void delete(UUID id, UUID profileId) {
+        if (!goalRepositoryPort.existsByIdAndProfileId(id, profileId)) {
+            throw new ResourceNotFoundException("Meta não encontrada.");
+        }
+        goalRepositoryPort.delete(id);
+    }
+}

--- a/poupeai-core-business/src/test/java/io/github/poupeai/core/business/adapter/GoalDepositServiceAdapterTest.java
+++ b/poupeai-core-business/src/test/java/io/github/poupeai/core/business/adapter/GoalDepositServiceAdapterTest.java
@@ -1,0 +1,219 @@
+package io.github.poupeai.core.business.adapter;
+
+import io.github.poupeai.core.domain.exception.ResourceNotFoundException;
+import io.github.poupeai.core.domain.model.GoalDeposit;
+import io.github.poupeai.core.domain.port.persistence.GoalDepositRepositoryPort;
+import io.github.poupeai.core.domain.port.persistence.GoalRepositoryPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GoalDepositServiceAdapterTest {
+
+    @Mock
+    private GoalDepositRepositoryPort goalDepositRepositoryPort;
+
+    @Mock
+    private GoalRepositoryPort goalRepositoryPort;
+
+    @InjectMocks
+    private GoalDepositServiceAdapter goalDepositServiceAdapter;
+
+    @Test
+    @DisplayName("Should create deposit successfully when goal exists")
+    void shouldCreateDepositSuccessfully() {
+        UUID goalId = UUID.randomUUID();
+        UUID profileId = UUID.randomUUID();
+        GoalDeposit deposit = GoalDeposit.builder()
+                .goalId(goalId)
+                .depositAmount(BigDecimal.valueOf(500))
+                .depositDate(LocalDate.now())
+                .build();
+
+        when(goalRepositoryPort.existsByIdAndProfileId(goalId, profileId)).thenReturn(true);
+        when(goalDepositRepositoryPort.create(deposit)).thenReturn(deposit);
+
+        GoalDeposit result = goalDepositServiceAdapter.create(deposit, profileId);
+
+        assertNotNull(result);
+        assertEquals(deposit.getDepositAmount(), result.getDepositAmount());
+        verify(goalRepositoryPort).existsByIdAndProfileId(goalId, profileId);
+        verify(goalDepositRepositoryPort).create(deposit);
+    }
+
+    @Test
+    @DisplayName("Should throw ResourceNotFoundException when creating deposit for non-existent goal")
+    void shouldThrowExceptionWhenCreatingDepositForNonExistentGoal() {
+        UUID goalId = UUID.randomUUID();
+        UUID profileId = UUID.randomUUID();
+        GoalDeposit deposit = GoalDeposit.builder()
+                .goalId(goalId)
+                .depositAmount(BigDecimal.valueOf(500))
+                .build();
+
+        when(goalRepositoryPort.existsByIdAndProfileId(goalId, profileId)).thenReturn(false);
+
+        assertThrows(ResourceNotFoundException.class, 
+            () -> goalDepositServiceAdapter.create(deposit, profileId));
+        verify(goalDepositRepositoryPort, never()).create(any());
+    }
+
+    @Test
+    @DisplayName("Should find all deposits by goal id successfully")
+    void shouldFindAllDepositsByGoalId() {
+        UUID goalId = UUID.randomUUID();
+        UUID profileId = UUID.randomUUID();
+        List<GoalDeposit> deposits = List.of(
+            GoalDeposit.builder().depositAmount(BigDecimal.valueOf(100)).build(),
+            GoalDeposit.builder().depositAmount(BigDecimal.valueOf(200)).build()
+        );
+
+        when(goalRepositoryPort.existsByIdAndProfileId(goalId, profileId)).thenReturn(true);
+        when(goalDepositRepositoryPort.findAllByGoalId(goalId)).thenReturn(deposits);
+
+        List<GoalDeposit> result = goalDepositServiceAdapter.findAllByGoalId(goalId, profileId);
+
+        assertEquals(2, result.size());
+        verify(goalRepositoryPort).existsByIdAndProfileId(goalId, profileId);
+        verify(goalDepositRepositoryPort).findAllByGoalId(goalId);
+    }
+
+    @Test
+    @DisplayName("Should throw ResourceNotFoundException when finding deposits for non-existent goal")
+    void shouldThrowExceptionWhenFindingDepositsForNonExistentGoal() {
+        UUID goalId = UUID.randomUUID();
+        UUID profileId = UUID.randomUUID();
+
+        when(goalRepositoryPort.existsByIdAndProfileId(goalId, profileId)).thenReturn(false);
+
+        assertThrows(ResourceNotFoundException.class, 
+            () -> goalDepositServiceAdapter.findAllByGoalId(goalId, profileId));
+        verify(goalDepositRepositoryPort, never()).findAllByGoalId(any());
+    }
+
+    @Test
+    @DisplayName("Should return empty list when goal has no deposits")
+    void shouldReturnEmptyListWhenGoalHasNoDeposits() {
+        UUID goalId = UUID.randomUUID();
+        UUID profileId = UUID.randomUUID();
+
+        when(goalRepositoryPort.existsByIdAndProfileId(goalId, profileId)).thenReturn(true);
+        when(goalDepositRepositoryPort.findAllByGoalId(goalId)).thenReturn(List.of());
+
+        List<GoalDeposit> result = goalDepositServiceAdapter.findAllByGoalId(goalId, profileId);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should delete deposit successfully when goal and deposit exist")
+    void shouldDeleteDepositSuccessfully() {
+        UUID goalId = UUID.randomUUID();
+        UUID depositId = UUID.randomUUID();
+        UUID profileId = UUID.randomUUID();
+        GoalDeposit deposit = GoalDeposit.builder().id(depositId).goalId(goalId).build();
+
+        when(goalRepositoryPort.existsByIdAndProfileId(goalId, profileId)).thenReturn(true);
+        when(goalDepositRepositoryPort.findByIdAndGoalId(depositId, goalId)).thenReturn(Optional.of(deposit));
+        doNothing().when(goalDepositRepositoryPort).delete(depositId);
+
+        goalDepositServiceAdapter.delete(goalId, depositId, profileId);
+
+        verify(goalRepositoryPort).existsByIdAndProfileId(goalId, profileId);
+        verify(goalDepositRepositoryPort).findByIdAndGoalId(depositId, goalId);
+        verify(goalDepositRepositoryPort).delete(depositId);
+    }
+
+    @Test
+    @DisplayName("Should throw ResourceNotFoundException when deleting deposit from non-existent goal")
+    void shouldThrowExceptionWhenDeletingDepositFromNonExistentGoal() {
+        UUID goalId = UUID.randomUUID();
+        UUID depositId = UUID.randomUUID();
+        UUID profileId = UUID.randomUUID();
+
+        when(goalRepositoryPort.existsByIdAndProfileId(goalId, profileId)).thenReturn(false);
+
+        assertThrows(ResourceNotFoundException.class, 
+            () -> goalDepositServiceAdapter.delete(goalId, depositId, profileId));
+        verify(goalDepositRepositoryPort, never()).findByIdAndGoalId(any(), any());
+        verify(goalDepositRepositoryPort, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("Should throw ResourceNotFoundException when deleting non-existent deposit")
+    void shouldThrowExceptionWhenDeletingNonExistentDeposit() {
+        UUID goalId = UUID.randomUUID();
+        UUID depositId = UUID.randomUUID();
+        UUID profileId = UUID.randomUUID();
+
+        when(goalRepositoryPort.existsByIdAndProfileId(goalId, profileId)).thenReturn(true);
+        when(goalDepositRepositoryPort.findByIdAndGoalId(depositId, goalId)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, 
+            () -> goalDepositServiceAdapter.delete(goalId, depositId, profileId));
+        verify(goalDepositRepositoryPort, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("Should create deposit with specific date")
+    void shouldCreateDepositWithSpecificDate() {
+        UUID goalId = UUID.randomUUID();
+        UUID profileId = UUID.randomUUID();
+        LocalDate specificDate = LocalDate.of(2025, 1, 15);
+        GoalDeposit deposit = GoalDeposit.builder()
+                .goalId(goalId)
+                .depositAmount(BigDecimal.valueOf(1000))
+                .depositDate(specificDate)
+                .build();
+
+        when(goalRepositoryPort.existsByIdAndProfileId(goalId, profileId)).thenReturn(true);
+        when(goalDepositRepositoryPort.create(deposit)).thenReturn(deposit);
+
+        GoalDeposit result = goalDepositServiceAdapter.create(deposit, profileId);
+
+        assertNotNull(result);
+        assertEquals(specificDate, result.getDepositDate());
+    }
+
+    @Test
+    @DisplayName("Should create multiple deposits for same goal")
+    void shouldCreateMultipleDepositsForSameGoal() {
+        UUID goalId = UUID.randomUUID();
+        UUID profileId = UUID.randomUUID();
+        GoalDeposit deposit1 = GoalDeposit.builder()
+                .goalId(goalId)
+                .depositAmount(BigDecimal.valueOf(100))
+                .depositDate(LocalDate.now())
+                .build();
+        GoalDeposit deposit2 = GoalDeposit.builder()
+                .goalId(goalId)
+                .depositAmount(BigDecimal.valueOf(200))
+                .depositDate(LocalDate.now())
+                .build();
+
+        when(goalRepositoryPort.existsByIdAndProfileId(goalId, profileId)).thenReturn(true);
+        when(goalDepositRepositoryPort.create(deposit1)).thenReturn(deposit1);
+        when(goalDepositRepositoryPort.create(deposit2)).thenReturn(deposit2);
+
+        GoalDeposit result1 = goalDepositServiceAdapter.create(deposit1, profileId);
+        GoalDeposit result2 = goalDepositServiceAdapter.create(deposit2, profileId);
+
+        assertNotNull(result1);
+        assertNotNull(result2);
+        verify(goalDepositRepositoryPort, times(2)).create(any());
+    }
+}

--- a/poupeai-core-business/src/test/java/io/github/poupeai/core/business/adapter/GoalServiceAdapterTest.java
+++ b/poupeai-core-business/src/test/java/io/github/poupeai/core/business/adapter/GoalServiceAdapterTest.java
@@ -1,0 +1,196 @@
+package io.github.poupeai.core.business.adapter;
+
+import io.github.poupeai.core.domain.exception.ResourceNotFoundException;
+import io.github.poupeai.core.domain.model.Goal;
+import io.github.poupeai.core.domain.port.persistence.GoalRepositoryPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GoalServiceAdapterTest {
+
+    @Mock
+    private GoalRepositoryPort goalRepositoryPort;
+
+    @InjectMocks
+    private GoalServiceAdapter goalServiceAdapter;
+
+    @Test
+    @DisplayName("Should create goal successfully")
+    void shouldCreateGoalSuccessfully() {
+        Goal goal = Goal.builder()
+                .profileId(UUID.randomUUID())
+                .name("Emergency Fund")
+                .goalAmount(BigDecimal.valueOf(10000))
+                .targetDate(LocalDate.now().plusMonths(12))
+                .build();
+
+        when(goalRepositoryPort.create(goal)).thenReturn(goal);
+
+        Goal result = goalServiceAdapter.create(goal);
+
+        assertNotNull(result);
+        assertEquals(goal.getName(), result.getName());
+        assertEquals(goal.getGoalAmount(), result.getGoalAmount());
+        verify(goalRepositoryPort).create(goal);
+    }
+
+    @Test
+    @DisplayName("Should update goal successfully")
+    void shouldUpdateGoalSuccessfully() {
+        UUID id = UUID.randomUUID();
+        Goal goal = Goal.builder()
+                .id(id)
+                .profileId(UUID.randomUUID())
+                .name("Updated Goal")
+                .goalAmount(BigDecimal.valueOf(15000))
+                .build();
+
+        when(goalRepositoryPort.update(goal)).thenReturn(goal);
+
+        Goal result = goalServiceAdapter.update(goal);
+
+        assertNotNull(result);
+        assertEquals("Updated Goal", result.getName());
+        verify(goalRepositoryPort).update(goal);
+    }
+
+    @Test
+    @DisplayName("Should find goal by id successfully")
+    void shouldFindByIdSuccessfully() {
+        UUID id = UUID.randomUUID();
+        UUID profileId = UUID.randomUUID();
+        Goal goal = Goal.builder()
+                .id(id)
+                .profileId(profileId)
+                .name("Vacation Fund")
+                .build();
+
+        when(goalRepositoryPort.findByIdAndProfileId(id, profileId)).thenReturn(Optional.of(goal));
+
+        Goal result = goalServiceAdapter.findByIdAndProfileId(id, profileId);
+
+        assertNotNull(result);
+        assertEquals(id, result.getId());
+        assertEquals("Vacation Fund", result.getName());
+    }
+
+    @Test
+    @DisplayName("Should throw ResourceNotFoundException when goal not found by id")
+    void shouldThrowExceptionWhenGoalNotFound() {
+        UUID id = UUID.randomUUID();
+        UUID profileId = UUID.randomUUID();
+        when(goalRepositoryPort.findByIdAndProfileId(id, profileId)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, 
+            () -> goalServiceAdapter.findByIdAndProfileId(id, profileId));
+    }
+
+    @Test
+    @DisplayName("Should find all goals by profile id")
+    void shouldFindAllByProfileId() {
+        UUID profileId = UUID.randomUUID();
+        List<Goal> goals = List.of(
+            Goal.builder().name("Goal 1").build(),
+            Goal.builder().name("Goal 2").build()
+        );
+
+        when(goalRepositoryPort.findAllByProfileId(profileId)).thenReturn(goals);
+
+        List<Goal> result = goalServiceAdapter.findAllByProfileId(profileId);
+
+        assertEquals(2, result.size());
+        verify(goalRepositoryPort).findAllByProfileId(profileId);
+    }
+
+    @Test
+    @DisplayName("Should return empty list when no goals found")
+    void shouldReturnEmptyListWhenNoGoals() {
+        UUID profileId = UUID.randomUUID();
+        when(goalRepositoryPort.findAllByProfileId(profileId)).thenReturn(List.of());
+
+        List<Goal> result = goalServiceAdapter.findAllByProfileId(profileId);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should delete goal successfully")
+    void shouldDeleteGoalSuccessfully() {
+        UUID id = UUID.randomUUID();
+        UUID profileId = UUID.randomUUID();
+
+        when(goalRepositoryPort.existsByIdAndProfileId(id, profileId)).thenReturn(true);
+        doNothing().when(goalRepositoryPort).delete(id);
+
+        goalServiceAdapter.delete(id, profileId);
+
+        verify(goalRepositoryPort).existsByIdAndProfileId(id, profileId);
+        verify(goalRepositoryPort).delete(id);
+    }
+
+    @Test
+    @DisplayName("Should throw ResourceNotFoundException when deleting non-existent goal")
+    void shouldThrowExceptionWhenDeletingNonExistentGoal() {
+        UUID id = UUID.randomUUID();
+        UUID profileId = UUID.randomUUID();
+
+        when(goalRepositoryPort.existsByIdAndProfileId(id, profileId)).thenReturn(false);
+
+        assertThrows(ResourceNotFoundException.class, 
+            () -> goalServiceAdapter.delete(id, profileId));
+        verify(goalRepositoryPort, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("Should create goal with completed date")
+    void shouldCreateGoalWithCompletedDate() {
+        Goal goal = Goal.builder()
+                .profileId(UUID.randomUUID())
+                .name("Completed Goal")
+                .goalAmount(BigDecimal.valueOf(5000))
+                .completedAt(LocalDate.now())
+                .build();
+
+        when(goalRepositoryPort.create(goal)).thenReturn(goal);
+
+        Goal result = goalServiceAdapter.create(goal);
+
+        assertNotNull(result);
+        assertNotNull(result.getCompletedAt());
+    }
+
+    @Test
+    @DisplayName("Should update goal marking as completed")
+    void shouldUpdateGoalMarkingAsCompleted() {
+        UUID id = UUID.randomUUID();
+        Goal goal = Goal.builder()
+                .id(id)
+                .profileId(UUID.randomUUID())
+                .name("Goal")
+                .goalAmount(BigDecimal.valueOf(5000))
+                .completedAt(LocalDate.now())
+                .build();
+
+        when(goalRepositoryPort.update(goal)).thenReturn(goal);
+
+        Goal result = goalServiceAdapter.update(goal);
+
+        assertNotNull(result);
+        assertNotNull(result.getCompletedAt());
+    }
+}

--- a/poupeai-core-domain/src/main/java/io/github/poupeai/core/domain/model/Goal.java
+++ b/poupeai-core-domain/src/main/java/io/github/poupeai/core/domain/model/Goal.java
@@ -1,0 +1,26 @@
+package io.github.poupeai.core.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Goal {
+    private UUID id;
+    private UUID profileId;
+    private String name;
+    private BigDecimal goalAmount;
+    private LocalDate targetDate;
+    private LocalDate completedAt;
+    private OffsetDateTime createdAt;
+    private OffsetDateTime updatedAt;
+}

--- a/poupeai-core-domain/src/main/java/io/github/poupeai/core/domain/model/GoalDeposit.java
+++ b/poupeai-core-domain/src/main/java/io/github/poupeai/core/domain/model/GoalDeposit.java
@@ -1,0 +1,23 @@
+package io.github.poupeai.core.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GoalDeposit {
+    private UUID id;
+    private UUID goalId;
+    private BigDecimal depositAmount;
+    private LocalDate depositDate;
+    private OffsetDateTime createdAt;
+}

--- a/poupeai-core-domain/src/main/java/io/github/poupeai/core/domain/port/business/GoalDepositServicePort.java
+++ b/poupeai-core-domain/src/main/java/io/github/poupeai/core/domain/port/business/GoalDepositServicePort.java
@@ -1,0 +1,12 @@
+package io.github.poupeai.core.domain.port.business;
+
+import io.github.poupeai.core.domain.model.GoalDeposit;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface GoalDepositServicePort {
+    GoalDeposit create(GoalDeposit goalDeposit, UUID profileId);
+    List<GoalDeposit> findAllByGoalId(UUID goalId, UUID profileId);
+    void delete(UUID goalId, UUID depositId, UUID profileId);
+}

--- a/poupeai-core-domain/src/main/java/io/github/poupeai/core/domain/port/business/GoalServicePort.java
+++ b/poupeai-core-domain/src/main/java/io/github/poupeai/core/domain/port/business/GoalServicePort.java
@@ -1,0 +1,14 @@
+package io.github.poupeai.core.domain.port.business;
+
+import io.github.poupeai.core.domain.model.Goal;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface GoalServicePort {
+    Goal create(Goal goal);
+    Goal update(Goal goal);
+    Goal findByIdAndProfileId(UUID id, UUID profileId);
+    List<Goal> findAllByProfileId(UUID profileId);
+    void delete(UUID id, UUID profileId);
+}

--- a/poupeai-core-domain/src/main/java/io/github/poupeai/core/domain/port/persistence/GoalDepositRepositoryPort.java
+++ b/poupeai-core-domain/src/main/java/io/github/poupeai/core/domain/port/persistence/GoalDepositRepositoryPort.java
@@ -1,0 +1,14 @@
+package io.github.poupeai.core.domain.port.persistence;
+
+import io.github.poupeai.core.domain.model.GoalDeposit;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface GoalDepositRepositoryPort {
+    GoalDeposit create(GoalDeposit goalDeposit);
+    List<GoalDeposit> findAllByGoalId(UUID goalId);
+    Optional<GoalDeposit> findByIdAndGoalId(UUID id, UUID goalId);
+    void delete(UUID id);
+}

--- a/poupeai-core-domain/src/main/java/io/github/poupeai/core/domain/port/persistence/GoalRepositoryPort.java
+++ b/poupeai-core-domain/src/main/java/io/github/poupeai/core/domain/port/persistence/GoalRepositoryPort.java
@@ -1,0 +1,16 @@
+package io.github.poupeai.core.domain.port.persistence;
+
+import io.github.poupeai.core.domain.model.Goal;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface GoalRepositoryPort {
+    Goal create(Goal goal);
+    Goal update(Goal goal);
+    Optional<Goal> findByIdAndProfileId(UUID id, UUID profileId);
+    List<Goal> findAllByProfileId(UUID profileId);
+    void delete(UUID id);
+    boolean existsByIdAndProfileId(UUID id, UUID profileId);
+}

--- a/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/adapter/CategoryRepositoryAdapter.java
+++ b/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/adapter/CategoryRepositoryAdapter.java
@@ -27,9 +27,6 @@ public class CategoryRepositoryAdapter implements CategoryRepositoryPort {
         
         var profile = profileRepository.getReferenceById(category.getProfileId());
         entity.setProfile(profile);
-
-        entity.setCreatedAt(OffsetDateTime.now());
-        entity.setUpdatedAt(OffsetDateTime.now());
         
         var savedEntity = categoryRepository.save(entity);
         return categoryMapper.toDomain(savedEntity);
@@ -46,7 +43,6 @@ public class CategoryRepositoryAdapter implements CategoryRepositoryPort {
         existingCategory.setColorHex(category.getColorHex());
         existingCategory.setIconName(category.getIconName());
         existingCategory.setType(category.getType());
-        existingCategory.setUpdatedAt(OffsetDateTime.now());
 
         var savedEntity = categoryRepository.save(existingCategory);
         return categoryMapper.toDomain(savedEntity);

--- a/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/adapter/GoalDepositRepositoryAdapter.java
+++ b/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/adapter/GoalDepositRepositoryAdapter.java
@@ -26,8 +26,6 @@ public class GoalDepositRepositoryAdapter implements GoalDepositRepositoryPort {
         
         var goal = goalRepository.getReferenceById(goalDeposit.getGoalId());
         entity.setGoal(goal);
-
-        entity.setCreatedAt(OffsetDateTime.now());
         
         var savedEntity = goalDepositRepository.save(entity);
         return goalDepositMapper.toDomain(savedEntity);

--- a/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/adapter/GoalDepositRepositoryAdapter.java
+++ b/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/adapter/GoalDepositRepositoryAdapter.java
@@ -1,0 +1,51 @@
+package io.github.poupeai.core.persistence.adapter;
+
+import io.github.poupeai.core.domain.model.GoalDeposit;
+import io.github.poupeai.core.domain.port.persistence.GoalDepositRepositoryPort;
+import io.github.poupeai.core.persistence.mapper.GoalDepositEntityMapper;
+import io.github.poupeai.core.persistence.repository.GoalDepositRepository;
+import io.github.poupeai.core.persistence.repository.GoalRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class GoalDepositRepositoryAdapter implements GoalDepositRepositoryPort {
+    private final GoalDepositRepository goalDepositRepository;
+    private final GoalDepositEntityMapper goalDepositMapper;
+    private final GoalRepository goalRepository;
+
+    @Override
+    public GoalDeposit create(GoalDeposit goalDeposit) {
+        var entity = goalDepositMapper.toEntity(goalDeposit);
+        
+        var goal = goalRepository.getReferenceById(goalDeposit.getGoalId());
+        entity.setGoal(goal);
+
+        entity.setCreatedAt(OffsetDateTime.now());
+        
+        var savedEntity = goalDepositRepository.save(entity);
+        return goalDepositMapper.toDomain(savedEntity);
+    }
+
+    @Override
+    public List<GoalDeposit> findAllByGoalId(UUID goalId) {
+        var entities = goalDepositRepository.findAllByGoal_Id(goalId);
+        return goalDepositMapper.toDomainList(entities);
+    }
+
+    @Override
+    public Optional<GoalDeposit> findByIdAndGoalId(UUID id, UUID goalId) {
+        return goalDepositRepository.findByIdAndGoal_Id(id, goalId).map(goalDepositMapper::toDomain);
+    }
+
+    @Override
+    public void delete(UUID id) {
+        goalDepositRepository.deleteById(id);
+    }
+}

--- a/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/adapter/GoalRepositoryAdapter.java
+++ b/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/adapter/GoalRepositoryAdapter.java
@@ -27,9 +27,6 @@ public class GoalRepositoryAdapter implements GoalRepositoryPort {
         
         var profile = profileRepository.getReferenceById(goal.getProfileId());
         entity.setProfile(profile);
-
-        entity.setCreatedAt(OffsetDateTime.now());
-        entity.setUpdatedAt(OffsetDateTime.now());
         
         var savedEntity = goalRepository.save(entity);
         return goalMapper.toDomain(savedEntity);
@@ -46,7 +43,6 @@ public class GoalRepositoryAdapter implements GoalRepositoryPort {
         existingGoal.setGoalAmount(goal.getGoalAmount());
         existingGoal.setTargetDate(goal.getTargetDate());
         existingGoal.setCompletedAt(goal.getCompletedAt());
-        existingGoal.setUpdatedAt(OffsetDateTime.now());
 
         var savedEntity = goalRepository.save(existingGoal);
         return goalMapper.toDomain(savedEntity);

--- a/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/adapter/GoalRepositoryAdapter.java
+++ b/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/adapter/GoalRepositoryAdapter.java
@@ -1,0 +1,75 @@
+package io.github.poupeai.core.persistence.adapter;
+
+import io.github.poupeai.core.domain.exception.ResourceNotFoundException;
+import io.github.poupeai.core.domain.model.Goal;
+import io.github.poupeai.core.domain.port.persistence.GoalRepositoryPort;
+import io.github.poupeai.core.persistence.mapper.GoalEntityMapper;
+import io.github.poupeai.core.persistence.repository.GoalRepository;
+import io.github.poupeai.core.persistence.repository.ProfileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class GoalRepositoryAdapter implements GoalRepositoryPort {
+    private final GoalRepository goalRepository;
+    private final GoalEntityMapper goalMapper;
+    private final ProfileRepository profileRepository;
+
+    @Override
+    public Goal create(Goal goal) {
+        var entity = goalMapper.toEntity(goal);
+        
+        var profile = profileRepository.getReferenceById(goal.getProfileId());
+        entity.setProfile(profile);
+
+        entity.setCreatedAt(OffsetDateTime.now());
+        entity.setUpdatedAt(OffsetDateTime.now());
+        
+        var savedEntity = goalRepository.save(entity);
+        return goalMapper.toDomain(savedEntity);
+    }
+
+    @Override
+    public Goal update(Goal goal) {
+        var existingGoal = goalRepository.findById(goal.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Meta não encontrada."));
+        
+        var profile = profileRepository.getReferenceById(goal.getProfileId());
+        existingGoal.setProfile(profile);
+        existingGoal.setName(goal.getName());
+        existingGoal.setGoalAmount(goal.getGoalAmount());
+        existingGoal.setTargetDate(goal.getTargetDate());
+        existingGoal.setCompletedAt(goal.getCompletedAt());
+        existingGoal.setUpdatedAt(OffsetDateTime.now());
+
+        var savedEntity = goalRepository.save(existingGoal);
+        return goalMapper.toDomain(savedEntity);
+    }
+
+    @Override
+    public Optional<Goal> findByIdAndProfileId(UUID id, UUID profileId) {
+        return goalRepository.findByIdAndProfile_UserId(id, profileId).map(goalMapper::toDomain);
+    }
+
+    @Override
+    public List<Goal> findAllByProfileId(UUID profileId) {
+        var entities = goalRepository.findAllByProfile_UserId(profileId);
+        return goalMapper.toDomainList(entities);
+    }
+
+    @Override
+    public void delete(UUID id) {
+        goalRepository.deleteById(id);
+    }
+
+    @Override
+    public boolean existsByIdAndProfileId(UUID id, UUID profileId) {
+        return goalRepository.existsByIdAndProfile_UserId(id, profileId);
+    }
+}

--- a/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/entity/GoalDepositEntity.java
+++ b/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/entity/GoalDepositEntity.java
@@ -1,0 +1,50 @@
+package io.github.poupeai.core.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "goal_deposits")
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class GoalDepositEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "goal_id", nullable = false,
+        foreignKey = @ForeignKey(name = "fk_goal_deposit_goal")
+    )
+    private GoalEntity goal;
+
+    @Column(name = "deposit_amount", nullable = false, precision = 15, scale = 2)
+    private BigDecimal depositAmount;
+
+    @Column(name = "deposit_date", nullable = false)
+    private LocalDate depositDate;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private OffsetDateTime createdAt;
+}

--- a/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/entity/GoalEntity.java
+++ b/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/entity/GoalEntity.java
@@ -1,0 +1,61 @@
+package io.github.poupeai.core.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "goals")
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class GoalEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "profile_id", referencedColumnName = "user_id", nullable = false,
+        foreignKey = @ForeignKey(name = "fk_goal_profile")
+    )
+    private ProfileEntity profile;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "goal_amount", nullable = false, precision = 15, scale = 2)
+    private BigDecimal goalAmount;
+
+    @Column(name = "target_date")
+    private LocalDate targetDate;
+
+    @Column(name = "completed_at")
+    private LocalDate completedAt;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private OffsetDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private OffsetDateTime updatedAt;
+}

--- a/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/mapper/GoalDepositEntityMapper.java
+++ b/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/mapper/GoalDepositEntityMapper.java
@@ -1,0 +1,21 @@
+package io.github.poupeai.core.persistence.mapper;
+
+import io.github.poupeai.core.domain.model.GoalDeposit;
+import io.github.poupeai.core.persistence.entity.GoalDepositEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface GoalDepositEntityMapper {
+    @Mapping(target = "goalId", source = "goal.id")
+    GoalDeposit toDomain(GoalDepositEntity entity);
+
+    @Mapping(target = "goal", ignore = true)
+    GoalDepositEntity toEntity(GoalDeposit domain);
+
+    List<GoalDeposit> toDomainList(List<GoalDepositEntity> entities);
+
+    List<GoalDepositEntity> toEntityList(List<GoalDeposit> domains);
+}

--- a/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/mapper/GoalEntityMapper.java
+++ b/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/mapper/GoalEntityMapper.java
@@ -1,0 +1,21 @@
+package io.github.poupeai.core.persistence.mapper;
+
+import io.github.poupeai.core.domain.model.Goal;
+import io.github.poupeai.core.persistence.entity.GoalEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface GoalEntityMapper {
+    @Mapping(target = "profileId", source = "profile.userId")
+    Goal toDomain(GoalEntity entity);
+
+    @Mapping(target = "profile", ignore = true)
+    GoalEntity toEntity(Goal domain);
+
+    List<Goal> toDomainList(List<GoalEntity> entities);
+
+    List<GoalEntity> toEntityList(List<Goal> domains);
+}

--- a/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/repository/GoalDepositRepository.java
+++ b/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/repository/GoalDepositRepository.java
@@ -1,0 +1,15 @@
+package io.github.poupeai.core.persistence.repository;
+
+import io.github.poupeai.core.persistence.entity.GoalDepositEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface GoalDepositRepository extends JpaRepository<GoalDepositEntity, UUID> {
+    List<GoalDepositEntity> findAllByGoal_Id(UUID goalId);
+    Optional<GoalDepositEntity> findByIdAndGoal_Id(UUID id, UUID goalId);
+}

--- a/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/repository/GoalRepository.java
+++ b/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/repository/GoalRepository.java
@@ -1,0 +1,16 @@
+package io.github.poupeai.core.persistence.repository;
+
+import io.github.poupeai.core.persistence.entity.GoalEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface GoalRepository extends JpaRepository<GoalEntity, UUID> {
+    List<GoalEntity> findAllByProfile_UserId(UUID profileId);
+    Optional<GoalEntity> findByIdAndProfile_UserId(UUID id, UUID profileId);
+    boolean existsByIdAndProfile_UserId(UUID id, UUID profileId);
+}

--- a/poupeai-core-persistence/src/main/resources/db/migration/V3__create_table_goals.sql
+++ b/poupeai-core-persistence/src/main/resources/db/migration/V3__create_table_goals.sql
@@ -1,0 +1,28 @@
+CREATE TABLE goals (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    profile_id UUID NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    goal_amount DECIMAL(15, 2) NOT NULL,
+    target_date DATE,
+    completed_at DATE,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    
+    CONSTRAINT fk_goal_profile FOREIGN KEY (profile_id) 
+        REFERENCES profiles(user_id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_goals_profile_id ON goals(profile_id);
+
+CREATE TABLE goal_deposits (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    goal_id UUID NOT NULL,
+    deposit_amount DECIMAL(15, 2) NOT NULL,
+    deposit_date DATE NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    
+    CONSTRAINT fk_goal_deposit_goal FOREIGN KEY (goal_id) 
+        REFERENCES goals(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_goal_deposits_goal_id ON goal_deposits(goal_id);

--- a/poupeai-core-persistence/src/test/java/io/github/poupeai/core/persistence/adapter/CategoryRepositoryAdapterTest.java
+++ b/poupeai-core-persistence/src/test/java/io/github/poupeai/core/persistence/adapter/CategoryRepositoryAdapterTest.java
@@ -17,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.time.OffsetDateTime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -55,7 +56,12 @@ class CategoryRepositoryAdapterTest {
 
         when(categoryMapper.toEntity(domain)).thenReturn(entity);
         when(profileRepository.getReferenceById(profileId)).thenReturn(profileProxy);
-        when(categoryRepository.save(entity)).thenReturn(entity);
+        when(categoryRepository.save(entity)).thenAnswer(invocation -> {
+            CategoryEntity saved = invocation.getArgument(0);
+            saved.setCreatedAt(OffsetDateTime.now());
+            saved.setUpdatedAt(OffsetDateTime.now());
+            return saved;
+        });
         when(categoryMapper.toDomain(entity)).thenReturn(domain);
 
         Category result = adapter.create(domain);
@@ -82,7 +88,11 @@ class CategoryRepositoryAdapterTest {
         when(categoryRepository.findByIdAndProfile_UserId(catId, profileId))
                 .thenReturn(Optional.of(existingEntity));
         when(profileRepository.getReferenceById(any())).thenReturn(profileProxy);
-        when(categoryRepository.save(existingEntity)).thenReturn(existingEntity);
+        when(categoryRepository.save(existingEntity)).thenAnswer(invocation -> {
+            CategoryEntity saved = invocation.getArgument(0);
+            saved.setUpdatedAt(OffsetDateTime.now());
+            return saved;
+        });
         when(categoryMapper.toDomain(existingEntity)).thenReturn(domain);
 
         Category result = adapter.update(domain, profileId);

--- a/poupeai-core-persistence/src/test/java/io/github/poupeai/core/persistence/adapter/GoalDepositRepositoryAdapterTest.java
+++ b/poupeai-core-persistence/src/test/java/io/github/poupeai/core/persistence/adapter/GoalDepositRepositoryAdapterTest.java
@@ -1,0 +1,250 @@
+package io.github.poupeai.core.persistence.adapter;
+
+import io.github.poupeai.core.domain.model.GoalDeposit;
+import io.github.poupeai.core.persistence.entity.GoalDepositEntity;
+import io.github.poupeai.core.persistence.entity.GoalEntity;
+import io.github.poupeai.core.persistence.mapper.GoalDepositEntityMapper;
+import io.github.poupeai.core.persistence.repository.GoalDepositRepository;
+import io.github.poupeai.core.persistence.repository.GoalRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GoalDepositRepositoryAdapterTest {
+
+    @InjectMocks
+    private GoalDepositRepositoryAdapter adapter;
+
+    @Mock
+    private GoalDepositRepository goalDepositRepository;
+
+    @Mock
+    private GoalDepositEntityMapper goalDepositMapper;
+
+    @Mock
+    private GoalRepository goalRepository;
+
+    @Test
+    @DisplayName("Should persist deposit and link goal when data is valid")
+    void createShouldPersistWhenDataIsValid() {
+        UUID goalId = UUID.randomUUID();
+        GoalDeposit domain = GoalDeposit.builder()
+                .goalId(goalId)
+                .depositAmount(BigDecimal.valueOf(500))
+                .depositDate(LocalDate.now())
+                .build();
+
+        GoalDepositEntity entity = new GoalDepositEntity();
+        GoalEntity goalProxy = new GoalEntity();
+
+        when(goalDepositMapper.toEntity(domain)).thenReturn(entity);
+        when(goalRepository.getReferenceById(goalId)).thenReturn(goalProxy);
+        when(goalDepositRepository.save(entity)).thenReturn(entity);
+        when(goalDepositMapper.toDomain(entity)).thenReturn(domain);
+
+        GoalDeposit result = adapter.create(domain);
+
+        assertNotNull(result);
+        verify(goalDepositRepository).save(entity);
+        assertNotNull(entity.getCreatedAt());
+    }
+
+    @Test
+    @DisplayName("Should return list of deposits mapped to domain")
+    void findAllByGoalIdShouldReturnList() {
+        UUID goalId = UUID.randomUUID();
+        List<GoalDepositEntity> entities = List.of(
+            GoalDepositEntity.builder().depositAmount(BigDecimal.valueOf(100)).build(),
+            GoalDepositEntity.builder().depositAmount(BigDecimal.valueOf(200)).build()
+        );
+        List<GoalDeposit> domains = List.of(
+            GoalDeposit.builder().depositAmount(BigDecimal.valueOf(100)).build(),
+            GoalDeposit.builder().depositAmount(BigDecimal.valueOf(200)).build()
+        );
+
+        when(goalDepositRepository.findAllByGoal_Id(goalId)).thenReturn(entities);
+        when(goalDepositMapper.toDomainList(entities)).thenReturn(domains);
+
+        List<GoalDeposit> result = adapter.findAllByGoalId(goalId);
+
+        assertEquals(2, result.size());
+        verify(goalDepositRepository).findAllByGoal_Id(goalId);
+    }
+
+    @Test
+    @DisplayName("Should return empty list when goal has no deposits")
+    void findAllByGoalIdShouldReturnEmptyListWhenNoDeposits() {
+        UUID goalId = UUID.randomUUID();
+        when(goalDepositRepository.findAllByGoal_Id(goalId)).thenReturn(List.of());
+        when(goalDepositMapper.toDomainList(List.of())).thenReturn(List.of());
+
+        List<GoalDeposit> result = adapter.findAllByGoalId(goalId);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should return deposit when found by ID and Goal ID")
+    void findByIdAndGoalIdShouldReturnDepositWhenFound() {
+        UUID depositId = UUID.randomUUID();
+        UUID goalId = UUID.randomUUID();
+        GoalDepositEntity entity = new GoalDepositEntity();
+        GoalDeposit domain = new GoalDeposit();
+
+        when(goalDepositRepository.findByIdAndGoal_Id(depositId, goalId)).thenReturn(Optional.of(entity));
+        when(goalDepositMapper.toDomain(entity)).thenReturn(domain);
+
+        Optional<GoalDeposit> result = adapter.findByIdAndGoalId(depositId, goalId);
+
+        assertTrue(result.isPresent());
+        assertEquals(domain, result.get());
+    }
+
+    @Test
+    @DisplayName("Should return empty optional when deposit is not found by ID and Goal ID")
+    void findByIdAndGoalIdShouldReturnEmptyWhenNotFound() {
+        UUID depositId = UUID.randomUUID();
+        UUID goalId = UUID.randomUUID();
+        when(goalDepositRepository.findByIdAndGoal_Id(depositId, goalId)).thenReturn(Optional.empty());
+
+        Optional<GoalDeposit> result = adapter.findByIdAndGoalId(depositId, goalId);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should call delete by ID in repository")
+    void deleteShouldCallRepository() {
+        UUID id = UUID.randomUUID();
+        adapter.delete(id);
+        verify(goalDepositRepository).deleteById(id);
+    }
+
+    @Test
+    @DisplayName("Should create deposit with specific date")
+    void createShouldSetSpecificDate() {
+        UUID goalId = UUID.randomUUID();
+        LocalDate specificDate = LocalDate.of(2025, 6, 15);
+        GoalDeposit domain = GoalDeposit.builder()
+                .goalId(goalId)
+                .depositAmount(BigDecimal.valueOf(1000))
+                .depositDate(specificDate)
+                .build();
+
+        GoalDepositEntity entity = GoalDepositEntity.builder()
+                .depositDate(specificDate)
+                .build();
+        GoalEntity goalProxy = new GoalEntity();
+
+        when(goalDepositMapper.toEntity(domain)).thenReturn(entity);
+        when(goalRepository.getReferenceById(goalId)).thenReturn(goalProxy);
+        when(goalDepositRepository.save(entity)).thenReturn(entity);
+        when(goalDepositMapper.toDomain(entity)).thenReturn(domain);
+
+        GoalDeposit result = adapter.create(domain);
+
+        assertNotNull(result);
+        assertEquals(specificDate, entity.getDepositDate());
+    }
+
+    @Test
+    @DisplayName("Should create multiple deposits for same goal")
+    void createShouldAllowMultipleDepositsForSameGoal() {
+        UUID goalId = UUID.randomUUID();
+        GoalDeposit deposit1 = GoalDeposit.builder()
+                .goalId(goalId)
+                .depositAmount(BigDecimal.valueOf(100))
+                .depositDate(LocalDate.now())
+                .build();
+        GoalDeposit deposit2 = GoalDeposit.builder()
+                .goalId(goalId)
+                .depositAmount(BigDecimal.valueOf(200))
+                .depositDate(LocalDate.now())
+                .build();
+
+        GoalDepositEntity entity1 = new GoalDepositEntity();
+        GoalDepositEntity entity2 = new GoalDepositEntity();
+        GoalEntity goalProxy = new GoalEntity();
+
+        when(goalDepositMapper.toEntity(deposit1)).thenReturn(entity1);
+        when(goalDepositMapper.toEntity(deposit2)).thenReturn(entity2);
+        when(goalRepository.getReferenceById(goalId)).thenReturn(goalProxy);
+        when(goalDepositRepository.save(entity1)).thenReturn(entity1);
+        when(goalDepositRepository.save(entity2)).thenReturn(entity2);
+        when(goalDepositMapper.toDomain(entity1)).thenReturn(deposit1);
+        when(goalDepositMapper.toDomain(entity2)).thenReturn(deposit2);
+
+        GoalDeposit result1 = adapter.create(deposit1);
+        GoalDeposit result2 = adapter.create(deposit2);
+
+        assertNotNull(result1);
+        assertNotNull(result2);
+        verify(goalDepositRepository, times(2)).save(any());
+    }
+
+    @Test
+    @DisplayName("Should create deposit with large amount")
+    void createShouldHandleLargeAmount() {
+        UUID goalId = UUID.randomUUID();
+        BigDecimal largeAmount = BigDecimal.valueOf(999999.99);
+        GoalDeposit domain = GoalDeposit.builder()
+                .goalId(goalId)
+                .depositAmount(largeAmount)
+                .depositDate(LocalDate.now())
+                .build();
+
+        GoalDepositEntity entity = GoalDepositEntity.builder()
+                .depositAmount(largeAmount)
+                .build();
+        GoalEntity goalProxy = new GoalEntity();
+
+        when(goalDepositMapper.toEntity(domain)).thenReturn(entity);
+        when(goalRepository.getReferenceById(goalId)).thenReturn(goalProxy);
+        when(goalDepositRepository.save(entity)).thenReturn(entity);
+        when(goalDepositMapper.toDomain(entity)).thenReturn(domain);
+
+        GoalDeposit result = adapter.create(domain);
+
+        assertNotNull(result);
+        assertEquals(largeAmount, entity.getDepositAmount());
+    }
+
+    @Test
+    @DisplayName("Should find deposits ordered by repository default order")
+    void findAllShouldRespectRepositoryOrder() {
+        UUID goalId = UUID.randomUUID();
+        List<GoalDepositEntity> entities = List.of(
+            GoalDepositEntity.builder().id(UUID.randomUUID()).build(),
+            GoalDepositEntity.builder().id(UUID.randomUUID()).build(),
+            GoalDepositEntity.builder().id(UUID.randomUUID()).build()
+        );
+        List<GoalDeposit> domains = List.of(
+            GoalDeposit.builder().id(entities.get(0).getId()).build(),
+            GoalDeposit.builder().id(entities.get(1).getId()).build(),
+            GoalDeposit.builder().id(entities.get(2).getId()).build()
+        );
+
+        when(goalDepositRepository.findAllByGoal_Id(goalId)).thenReturn(entities);
+        when(goalDepositMapper.toDomainList(entities)).thenReturn(domains);
+
+        List<GoalDeposit> result = adapter.findAllByGoalId(goalId);
+
+        assertEquals(3, result.size());
+        assertEquals(domains.get(0).getId(), result.get(0).getId());
+        assertEquals(domains.get(1).getId(), result.get(1).getId());
+        assertEquals(domains.get(2).getId(), result.get(2).getId());
+    }
+}

--- a/poupeai-core-persistence/src/test/java/io/github/poupeai/core/persistence/adapter/GoalDepositRepositoryAdapterTest.java
+++ b/poupeai-core-persistence/src/test/java/io/github/poupeai/core/persistence/adapter/GoalDepositRepositoryAdapterTest.java
@@ -15,6 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -52,7 +53,11 @@ class GoalDepositRepositoryAdapterTest {
 
         when(goalDepositMapper.toEntity(domain)).thenReturn(entity);
         when(goalRepository.getReferenceById(goalId)).thenReturn(goalProxy);
-        when(goalDepositRepository.save(entity)).thenReturn(entity);
+        when(goalDepositRepository.save(entity)).thenAnswer(invocation -> {
+            GoalDepositEntity saved = invocation.getArgument(0);
+            saved.setCreatedAt(OffsetDateTime.now());
+            return saved;
+        });
         when(goalDepositMapper.toDomain(entity)).thenReturn(domain);
 
         GoalDeposit result = adapter.create(domain);

--- a/poupeai-core-persistence/src/test/java/io/github/poupeai/core/persistence/adapter/GoalRepositoryAdapterTest.java
+++ b/poupeai-core-persistence/src/test/java/io/github/poupeai/core/persistence/adapter/GoalRepositoryAdapterTest.java
@@ -16,6 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -54,7 +55,12 @@ class GoalRepositoryAdapterTest {
 
         when(goalMapper.toEntity(domain)).thenReturn(entity);
         when(profileRepository.getReferenceById(profileId)).thenReturn(profileProxy);
-        when(goalRepository.save(entity)).thenReturn(entity);
+        when(goalRepository.save(entity)).thenAnswer(invocation -> {
+            GoalEntity saved = invocation.getArgument(0);
+            saved.setCreatedAt(OffsetDateTime.now());
+            saved.setUpdatedAt(OffsetDateTime.now());
+            return saved;
+        });
         when(goalMapper.toDomain(entity)).thenReturn(domain);
 
         Goal result = adapter.create(domain);
@@ -82,7 +88,11 @@ class GoalRepositoryAdapterTest {
 
         when(goalRepository.findById(goalId)).thenReturn(Optional.of(existingEntity));
         when(profileRepository.getReferenceById(any())).thenReturn(profileProxy);
-        when(goalRepository.save(existingEntity)).thenReturn(existingEntity);
+        when(goalRepository.save(existingEntity)).thenAnswer(invocation -> {
+            GoalEntity saved = invocation.getArgument(0);
+            saved.setUpdatedAt(OffsetDateTime.now());
+            return saved;
+        });
         when(goalMapper.toDomain(existingEntity)).thenReturn(domain);
 
         Goal result = adapter.update(domain);
@@ -207,7 +217,11 @@ class GoalRepositoryAdapterTest {
 
         when(goalRepository.findById(goalId)).thenReturn(Optional.of(existingEntity));
         when(profileRepository.getReferenceById(any())).thenReturn(profileProxy);
-        when(goalRepository.save(existingEntity)).thenReturn(existingEntity);
+        when(goalRepository.save(existingEntity)).thenAnswer(invocation -> {
+            GoalEntity saved = invocation.getArgument(0);
+            saved.setUpdatedAt(OffsetDateTime.now());
+            return saved;
+        });
         when(goalMapper.toDomain(existingEntity)).thenReturn(domain);
 
         Goal result = adapter.update(domain);

--- a/poupeai-core-persistence/src/test/java/io/github/poupeai/core/persistence/adapter/GoalRepositoryAdapterTest.java
+++ b/poupeai-core-persistence/src/test/java/io/github/poupeai/core/persistence/adapter/GoalRepositoryAdapterTest.java
@@ -1,0 +1,244 @@
+package io.github.poupeai.core.persistence.adapter;
+
+import io.github.poupeai.core.domain.exception.ResourceNotFoundException;
+import io.github.poupeai.core.domain.model.Goal;
+import io.github.poupeai.core.persistence.entity.GoalEntity;
+import io.github.poupeai.core.persistence.entity.ProfileEntity;
+import io.github.poupeai.core.persistence.mapper.GoalEntityMapper;
+import io.github.poupeai.core.persistence.repository.GoalRepository;
+import io.github.poupeai.core.persistence.repository.ProfileRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GoalRepositoryAdapterTest {
+
+    @InjectMocks
+    private GoalRepositoryAdapter adapter;
+
+    @Mock
+    private GoalRepository goalRepository;
+
+    @Mock
+    private GoalEntityMapper goalMapper;
+
+    @Mock
+    private ProfileRepository profileRepository;
+
+    @Test
+    @DisplayName("Should persist goal and link profile when data is valid")
+    void createShouldPersistWhenDataIsValid() {
+        UUID profileId = UUID.randomUUID();
+        Goal domain = Goal.builder()
+                .profileId(profileId)
+                .name("Emergency Fund")
+                .goalAmount(BigDecimal.valueOf(10000))
+                .build();
+
+        GoalEntity entity = new GoalEntity();
+        ProfileEntity profileProxy = new ProfileEntity();
+
+        when(goalMapper.toEntity(domain)).thenReturn(entity);
+        when(profileRepository.getReferenceById(profileId)).thenReturn(profileProxy);
+        when(goalRepository.save(entity)).thenReturn(entity);
+        when(goalMapper.toDomain(entity)).thenReturn(domain);
+
+        Goal result = adapter.create(domain);
+
+        assertNotNull(result);
+        verify(goalRepository).save(entity);
+        assertNotNull(entity.getCreatedAt());
+        assertNotNull(entity.getUpdatedAt());
+    }
+
+    @Test
+    @DisplayName("Should update goal fields when goal exists")
+    void updateShouldUpdateFieldsWhenGoalExists() {
+        UUID goalId = UUID.randomUUID();
+        Goal domain = Goal.builder()
+                .id(goalId)
+                .profileId(UUID.randomUUID())
+                .name("Updated Goal")
+                .goalAmount(BigDecimal.valueOf(15000))
+                .targetDate(LocalDate.now().plusMonths(6))
+                .build();
+
+        GoalEntity existingEntity = new GoalEntity();
+        ProfileEntity profileProxy = new ProfileEntity();
+
+        when(goalRepository.findById(goalId)).thenReturn(Optional.of(existingEntity));
+        when(profileRepository.getReferenceById(any())).thenReturn(profileProxy);
+        when(goalRepository.save(existingEntity)).thenReturn(existingEntity);
+        when(goalMapper.toDomain(existingEntity)).thenReturn(domain);
+
+        Goal result = adapter.update(domain);
+
+        assertNotNull(result);
+        assertEquals("Updated Goal", existingEntity.getName());
+        assertEquals(BigDecimal.valueOf(15000), existingEntity.getGoalAmount());
+        assertNotNull(existingEntity.getUpdatedAt());
+    }
+
+    @Test
+    @DisplayName("Should throw ResourceNotFoundException when goal does not exist during update")
+    void updateShouldThrowNotFoundWhenGoalDoesNotExist() {
+        UUID goalId = UUID.randomUUID();
+        Goal domain = Goal.builder().id(goalId).build();
+
+        when(goalRepository.findById(goalId)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> adapter.update(domain));
+        verify(goalRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("Should return goal when found by ID and Profile ID")
+    void findByIdShouldReturnGoalWhenFound() {
+        UUID id = UUID.randomUUID();
+        UUID profileId = UUID.randomUUID();
+        GoalEntity entity = new GoalEntity();
+        Goal domain = new Goal();
+
+        when(goalRepository.findByIdAndProfile_UserId(id, profileId)).thenReturn(Optional.of(entity));
+        when(goalMapper.toDomain(entity)).thenReturn(domain);
+
+        Optional<Goal> result = adapter.findByIdAndProfileId(id, profileId);
+
+        assertTrue(result.isPresent());
+        assertEquals(domain, result.get());
+    }
+
+    @Test
+    @DisplayName("Should return empty optional when goal is not found by ID and Profile ID")
+    void findByIdShouldReturnEmptyWhenNotFound() {
+        UUID id = UUID.randomUUID();
+        UUID profileId = UUID.randomUUID();
+        when(goalRepository.findByIdAndProfile_UserId(id, profileId)).thenReturn(Optional.empty());
+
+        Optional<Goal> result = adapter.findByIdAndProfileId(id, profileId);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should return list of goals mapped to domain")
+    void findAllShouldReturnList() {
+        UUID profileId = UUID.randomUUID();
+        List<GoalEntity> entities = List.of(new GoalEntity(), new GoalEntity());
+        List<Goal> domains = List.of(new Goal(), new Goal());
+
+        when(goalRepository.findAllByProfile_UserId(profileId)).thenReturn(entities);
+        when(goalMapper.toDomainList(entities)).thenReturn(domains);
+
+        List<Goal> result = adapter.findAllByProfileId(profileId);
+
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    @DisplayName("Should return empty list when profile has no goals")
+    void findAllShouldReturnEmptyListWhenNoGoals() {
+        UUID profileId = UUID.randomUUID();
+        when(goalRepository.findAllByProfile_UserId(profileId)).thenReturn(List.of());
+        when(goalMapper.toDomainList(List.of())).thenReturn(List.of());
+
+        List<Goal> result = adapter.findAllByProfileId(profileId);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should call delete by ID in repository")
+    void deleteShouldCallRepository() {
+        UUID id = UUID.randomUUID();
+        adapter.delete(id);
+        verify(goalRepository).deleteById(id);
+    }
+
+    @Test
+    @DisplayName("Should return true when goal exists for the given profile")
+    void existsByIdShouldReturnTrue() {
+        UUID id = UUID.randomUUID();
+        UUID profileId = UUID.randomUUID();
+        when(goalRepository.existsByIdAndProfile_UserId(id, profileId)).thenReturn(true);
+
+        assertTrue(adapter.existsByIdAndProfileId(id, profileId));
+    }
+
+    @Test
+    @DisplayName("Should return false when goal does not exist for the given profile")
+    void existsByIdShouldReturnFalse() {
+        UUID id = UUID.randomUUID();
+        UUID profileId = UUID.randomUUID();
+        when(goalRepository.existsByIdAndProfile_UserId(id, profileId)).thenReturn(false);
+
+        assertFalse(adapter.existsByIdAndProfileId(id, profileId));
+    }
+
+    @Test
+    @DisplayName("Should update goal with completed date")
+    void updateShouldSetCompletedDate() {
+        UUID goalId = UUID.randomUUID();
+        LocalDate completedDate = LocalDate.now();
+        Goal domain = Goal.builder()
+                .id(goalId)
+                .profileId(UUID.randomUUID())
+                .name("Completed Goal")
+                .goalAmount(BigDecimal.valueOf(5000))
+                .completedAt(completedDate)
+                .build();
+
+        GoalEntity existingEntity = new GoalEntity();
+        ProfileEntity profileProxy = new ProfileEntity();
+
+        when(goalRepository.findById(goalId)).thenReturn(Optional.of(existingEntity));
+        when(profileRepository.getReferenceById(any())).thenReturn(profileProxy);
+        when(goalRepository.save(existingEntity)).thenReturn(existingEntity);
+        when(goalMapper.toDomain(existingEntity)).thenReturn(domain);
+
+        Goal result = adapter.update(domain);
+
+        assertNotNull(result);
+        assertEquals(completedDate, existingEntity.getCompletedAt());
+    }
+
+    @Test
+    @DisplayName("Should create goal with target date")
+    void createShouldSetTargetDate() {
+        UUID profileId = UUID.randomUUID();
+        LocalDate targetDate = LocalDate.now().plusYears(1);
+        Goal domain = Goal.builder()
+                .profileId(profileId)
+                .name("Long-term Goal")
+                .goalAmount(BigDecimal.valueOf(50000))
+                .targetDate(targetDate)
+                .build();
+
+        GoalEntity entity = GoalEntity.builder().targetDate(targetDate).build();
+        ProfileEntity profileProxy = new ProfileEntity();
+
+        when(goalMapper.toEntity(domain)).thenReturn(entity);
+        when(profileRepository.getReferenceById(profileId)).thenReturn(profileProxy);
+        when(goalRepository.save(entity)).thenReturn(entity);
+        when(goalMapper.toDomain(entity)).thenReturn(domain);
+
+        Goal result = adapter.create(domain);
+
+        assertNotNull(result);
+        assertEquals(targetDate, entity.getTargetDate());
+    }
+}

--- a/poupeai-core-web/src/main/java/io/github/poupeai/core/web/controller/goal/GoalController.java
+++ b/poupeai-core-web/src/main/java/io/github/poupeai/core/web/controller/goal/GoalController.java
@@ -1,0 +1,164 @@
+package io.github.poupeai.core.web.controller.goal;
+
+import io.github.poupeai.core.domain.model.Goal;
+import io.github.poupeai.core.domain.model.GoalDeposit;
+import io.github.poupeai.core.domain.port.business.GoalDepositServicePort;
+import io.github.poupeai.core.domain.port.business.GoalServicePort;
+import io.github.poupeai.core.web.dto.goal.GoalDepositRequest;
+import io.github.poupeai.core.web.dto.goal.GoalDepositResponse;
+import io.github.poupeai.core.web.dto.goal.GoalRequest;
+import io.github.poupeai.core.web.dto.goal.GoalResponse;
+import io.github.poupeai.core.web.dto.goal.GoalUpdateRequest;
+import io.github.poupeai.core.web.mapper.goal.GoalControllerMapper;
+import io.github.poupeai.core.web.mapper.goal.GoalDepositControllerMapper;
+import io.github.poupeai.core.web.security.CurrentUserId;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/goals")
+@RequiredArgsConstructor
+@Tag(name = "Metas", description = "Gerenciamento de Metas")
+public class GoalController {
+    private final GoalServicePort goalServicePort;
+    private final GoalDepositServicePort goalDepositServicePort;
+    private final GoalControllerMapper goalMapper;
+    private final GoalDepositControllerMapper goalDepositMapper;
+
+    @GetMapping
+    @Operation(
+        summary = "Obter minhas metas",
+        description = "Retorna todas as metas do usuário",
+        security = @SecurityRequirement(name = "bearer-key")
+    )
+    public ResponseEntity<List<GoalResponse>> getGoals(
+        @Parameter(hidden = true) @CurrentUserId String userId) {
+
+        List<Goal> goals = goalServicePort.findAllByProfileId(UUID.fromString(userId));
+        return ResponseEntity.ok(goalMapper.toResponseList(goals));
+    }
+
+    @GetMapping("/{id}")
+    @Operation(
+        summary = "Obter meta por ID",
+        description = "Retorna detalhes de uma meta específica",
+        security = @SecurityRequirement(name = "bearer-key")
+    )
+    public ResponseEntity<GoalResponse> getGoalById(
+        @Parameter(hidden = true) @CurrentUserId String userId,
+        @PathVariable UUID id) {
+
+        Goal goal = goalServicePort.findByIdAndProfileId(id, UUID.fromString(userId));
+        return ResponseEntity.ok(goalMapper.toResponse(goal));
+    }
+
+    @PostMapping
+    @Operation(
+        summary = "Criar meta",
+        description = "Cria uma nova meta",
+        security = @SecurityRequirement(name = "bearer-key")
+    )
+    public ResponseEntity<GoalResponse> createGoal(
+        @Parameter(hidden = true) @CurrentUserId String userId,
+        @RequestBody @Valid GoalRequest request) {
+
+        Goal goal = goalMapper.toDomain(request, UUID.fromString(userId));
+        Goal savedGoal = goalServicePort.create(goal);
+
+        return ResponseEntity.ok(goalMapper.toResponse(savedGoal));
+    }
+
+    @PatchMapping("/{id}")
+    @Operation(
+        summary = "Atualizar meta",
+        description = "Atualiza os dados de uma meta existente",
+        security = @SecurityRequirement(name = "bearer-key")
+    )
+    public ResponseEntity<GoalResponse> updateGoal(
+        @Parameter(hidden = true) @CurrentUserId String userId,
+        @PathVariable UUID id,
+        @RequestBody @Valid GoalUpdateRequest request) {
+
+        Goal goal = goalServicePort.findByIdAndProfileId(id, UUID.fromString(userId));
+        goalMapper.updateDomainFromDto(request, goal);
+        Goal updatedGoal = goalServicePort.update(goal);
+
+        return ResponseEntity.ok(goalMapper.toResponse(updatedGoal));
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(
+        summary = "Deletar meta",
+        description = "Deleta uma meta específica",
+        security = @SecurityRequirement(name = "bearer-key")
+    )
+    public ResponseEntity<Void> deleteGoal(
+        @Parameter(hidden = true) @CurrentUserId String userId,
+        @PathVariable UUID id) {
+
+        goalServicePort.delete(id, UUID.fromString(userId));
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{id}/deposits")
+    @Operation(
+        summary = "Adicionar depósito",
+        description = "Adiciona um depósito a uma meta",
+        security = @SecurityRequirement(name = "bearer-key")
+    )
+    public ResponseEntity<GoalDepositResponse> addDeposit(
+        @Parameter(hidden = true) @CurrentUserId String userId,
+        @PathVariable UUID id,
+        @RequestBody @Valid GoalDepositRequest request) {
+
+        GoalDeposit deposit = goalDepositMapper.toDomain(request, id);
+        GoalDeposit savedDeposit = goalDepositServicePort.create(deposit, UUID.fromString(userId));
+
+        return ResponseEntity.ok(goalDepositMapper.toResponse(savedDeposit));
+    }
+
+    @GetMapping("/{id}/deposits")
+    @Operation(
+        summary = "Obter depósitos da meta",
+        description = "Retorna todos os depósitos de uma meta",
+        security = @SecurityRequirement(name = "bearer-key")
+    )
+    public ResponseEntity<List<GoalDepositResponse>> getDeposits(
+        @Parameter(hidden = true) @CurrentUserId String userId,
+        @PathVariable UUID id) {
+
+        List<GoalDeposit> deposits = goalDepositServicePort.findAllByGoalId(id, UUID.fromString(userId));
+        return ResponseEntity.ok(goalDepositMapper.toResponseList(deposits));
+    }
+
+    @DeleteMapping("/{goal_id}/deposits/{deposit_id}")
+    @Operation(
+        summary = "Deletar depósito",
+        description = "Deleta um depósito de uma meta",
+        security = @SecurityRequirement(name = "bearer-key")
+    )
+    public ResponseEntity<Void> deleteDeposit(
+        @Parameter(hidden = true) @CurrentUserId String userId,
+        @PathVariable("goal_id") UUID goalId,
+        @PathVariable("deposit_id") UUID depositId) {
+
+        goalDepositServicePort.delete(goalId, depositId, UUID.fromString(userId));
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/poupeai-core-web/src/main/java/io/github/poupeai/core/web/dto/goal/GoalDepositRequest.java
+++ b/poupeai-core-web/src/main/java/io/github/poupeai/core/web/dto/goal/GoalDepositRequest.java
@@ -1,0 +1,24 @@
+package io.github.poupeai.core.web.dto.goal;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GoalDepositRequest {
+    @NotNull
+    @Positive
+    private BigDecimal depositAmount;
+    
+    @NotNull
+    private LocalDate depositDate;
+}

--- a/poupeai-core-web/src/main/java/io/github/poupeai/core/web/dto/goal/GoalDepositResponse.java
+++ b/poupeai-core-web/src/main/java/io/github/poupeai/core/web/dto/goal/GoalDepositResponse.java
@@ -1,0 +1,23 @@
+package io.github.poupeai.core.web.dto.goal;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GoalDepositResponse {
+    private UUID id;
+    private UUID goalId;
+    private BigDecimal depositAmount;
+    private LocalDate depositDate;
+    private OffsetDateTime createdAt;
+}

--- a/poupeai-core-web/src/main/java/io/github/poupeai/core/web/dto/goal/GoalRequest.java
+++ b/poupeai-core-web/src/main/java/io/github/poupeai/core/web/dto/goal/GoalRequest.java
@@ -1,0 +1,27 @@
+package io.github.poupeai.core.web.dto.goal;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GoalRequest {
+    @NotBlank
+    private String name;
+    
+    @NotNull
+    @Positive
+    private BigDecimal goalAmount;
+    
+    private LocalDate targetDate;
+}

--- a/poupeai-core-web/src/main/java/io/github/poupeai/core/web/dto/goal/GoalResponse.java
+++ b/poupeai-core-web/src/main/java/io/github/poupeai/core/web/dto/goal/GoalResponse.java
@@ -1,0 +1,25 @@
+package io.github.poupeai.core.web.dto.goal;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GoalResponse {
+    private UUID id;
+    private String name;
+    private BigDecimal goalAmount;
+    private LocalDate targetDate;
+    private LocalDate completedAt;
+    private OffsetDateTime createdAt;
+    private OffsetDateTime updatedAt;
+}

--- a/poupeai-core-web/src/main/java/io/github/poupeai/core/web/dto/goal/GoalUpdateRequest.java
+++ b/poupeai-core-web/src/main/java/io/github/poupeai/core/web/dto/goal/GoalUpdateRequest.java
@@ -1,0 +1,25 @@
+package io.github.poupeai.core.web.dto.goal;
+
+import jakarta.validation.constraints.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GoalUpdateRequest {
+    private String name;
+    
+    @Positive
+    private BigDecimal goalAmount;
+    
+    private LocalDate targetDate;
+    
+    private LocalDate completedAt;
+}

--- a/poupeai-core-web/src/main/java/io/github/poupeai/core/web/mapper/goal/GoalControllerMapper.java
+++ b/poupeai-core-web/src/main/java/io/github/poupeai/core/web/mapper/goal/GoalControllerMapper.java
@@ -1,0 +1,35 @@
+package io.github.poupeai.core.web.mapper.goal;
+
+import io.github.poupeai.core.domain.model.Goal;
+import io.github.poupeai.core.web.dto.goal.GoalRequest;
+import io.github.poupeai.core.web.dto.goal.GoalResponse;
+import io.github.poupeai.core.web.dto.goal.GoalUpdateRequest;
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+
+import java.util.List;
+import java.util.UUID;
+
+@Mapper(componentModel = "spring")
+public interface GoalControllerMapper {
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "profileId", source = "profileId")
+    @Mapping(target = "completedAt", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    Goal toDomain(GoalRequest request, UUID profileId);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "profileId", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    void updateDomainFromDto(GoalUpdateRequest dto, @MappingTarget Goal domain);
+
+    GoalResponse toResponse(Goal domain);
+    
+    List<GoalResponse> toResponseList(List<Goal> goals);
+}

--- a/poupeai-core-web/src/main/java/io/github/poupeai/core/web/mapper/goal/GoalDepositControllerMapper.java
+++ b/poupeai-core-web/src/main/java/io/github/poupeai/core/web/mapper/goal/GoalDepositControllerMapper.java
@@ -1,0 +1,22 @@
+package io.github.poupeai.core.web.mapper.goal;
+
+import io.github.poupeai.core.domain.model.GoalDeposit;
+import io.github.poupeai.core.web.dto.goal.GoalDepositRequest;
+import io.github.poupeai.core.web.dto.goal.GoalDepositResponse;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+import java.util.UUID;
+
+@Mapper(componentModel = "spring")
+public interface GoalDepositControllerMapper {
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "goalId", source = "goalId")
+    @Mapping(target = "createdAt", ignore = true)
+    GoalDeposit toDomain(GoalDepositRequest request, UUID goalId);
+
+    GoalDepositResponse toResponse(GoalDeposit domain);
+    
+    List<GoalDepositResponse> toResponseList(List<GoalDeposit> deposits);
+}

--- a/poupeai-core-web/src/test/java/io/github/poupeai/core/web/controller/goal/GoalControllerTest.java
+++ b/poupeai-core-web/src/test/java/io/github/poupeai/core/web/controller/goal/GoalControllerTest.java
@@ -1,0 +1,336 @@
+package io.github.poupeai.core.web.controller.goal;
+
+import io.github.poupeai.core.domain.model.Goal;
+import io.github.poupeai.core.domain.model.GoalDeposit;
+import io.github.poupeai.core.domain.port.business.GoalDepositServicePort;
+import io.github.poupeai.core.domain.port.business.GoalServicePort;
+import io.github.poupeai.core.web.dto.goal.*;
+import io.github.poupeai.core.web.mapper.goal.GoalControllerMapper;
+import io.github.poupeai.core.web.mapper.goal.GoalDepositControllerMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GoalControllerTest {
+
+    @Mock
+    private GoalServicePort goalServicePort;
+
+    @Mock
+    private GoalDepositServicePort goalDepositServicePort;
+
+    @Mock
+    private GoalControllerMapper goalMapper;
+
+    @Mock
+    private GoalDepositControllerMapper goalDepositMapper;
+
+    @InjectMocks
+    private GoalController goalController;
+
+    @Test
+    @DisplayName("Should get goals successfully")
+    void shouldGetGoalsSuccessfully() {
+        String userId = UUID.randomUUID().toString();
+        List<Goal> goals = List.of(
+            Goal.builder().name("Emergency Fund").build(),
+            Goal.builder().name("Vacation").build()
+        );
+        List<GoalResponse> responses = List.of(
+            new GoalResponse(),
+            new GoalResponse()
+        );
+
+        when(goalServicePort.findAllByProfileId(UUID.fromString(userId))).thenReturn(goals);
+        when(goalMapper.toResponseList(goals)).thenReturn(responses);
+
+        ResponseEntity<List<GoalResponse>> result = goalController.getGoals(userId);
+
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertEquals(responses, result.getBody());
+        assertEquals(2, result.getBody().size());
+    }
+
+    @Test
+    @DisplayName("Should get goal by id successfully when user is owner")
+    void shouldGetGoalByIdSuccessfully() {
+        UUID userId = UUID.randomUUID();
+        UUID goalId = UUID.randomUUID();
+        Goal goal = Goal.builder()
+                .id(goalId)
+                .profileId(userId)
+                .name("Emergency Fund")
+                .build();
+        GoalResponse response = new GoalResponse();
+
+        when(goalServicePort.findByIdAndProfileId(goalId, userId)).thenReturn(goal);
+        when(goalMapper.toResponse(goal)).thenReturn(response);
+
+        ResponseEntity<GoalResponse> result = goalController.getGoalById(userId.toString(), goalId);
+
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertEquals(response, result.getBody());
+    }
+
+    @Test
+    @DisplayName("Should create goal successfully")
+    void shouldCreateGoalSuccessfully() {
+        String userId = UUID.randomUUID().toString();
+        GoalRequest request = GoalRequest.builder()
+                .name("New Goal")
+                .goalAmount(BigDecimal.valueOf(10000))
+                .targetDate(LocalDate.now().plusMonths(12))
+                .build();
+        Goal goal = new Goal();
+        Goal savedGoal = Goal.builder()
+                .id(UUID.randomUUID())
+                .name("New Goal")
+                .build();
+        GoalResponse response = new GoalResponse();
+
+        when(goalMapper.toDomain(eq(request), any(UUID.class))).thenReturn(goal);
+        when(goalServicePort.create(goal)).thenReturn(savedGoal);
+        when(goalMapper.toResponse(savedGoal)).thenReturn(response);
+
+        ResponseEntity<GoalResponse> result = goalController.createGoal(userId, request);
+
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertEquals(response, result.getBody());
+        verify(goalServicePort).create(goal);
+    }
+
+    @Test
+    @DisplayName("Should update goal successfully when user is owner")
+    void shouldUpdateGoalSuccessfully() {
+        UUID userId = UUID.randomUUID();
+        UUID goalId = UUID.randomUUID();
+        GoalUpdateRequest request = GoalUpdateRequest.builder()
+                .name("Updated Goal")
+                .goalAmount(BigDecimal.valueOf(15000))
+                .build();
+        Goal goal = Goal.builder()
+                .id(goalId)
+                .profileId(userId)
+                .name("Old Name")
+                .build();
+        GoalResponse response = new GoalResponse();
+
+        when(goalServicePort.findByIdAndProfileId(goalId, userId)).thenReturn(goal);
+        doNothing().when(goalMapper).updateDomainFromDto(eq(request), eq(goal));
+        when(goalServicePort.update(goal)).thenReturn(goal);
+        when(goalMapper.toResponse(goal)).thenReturn(response);
+
+        ResponseEntity<GoalResponse> result = goalController.updateGoal(userId.toString(), goalId, request);
+
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertEquals(response, result.getBody());
+        verify(goalServicePort).update(goal);
+    }
+
+    @Test
+    @DisplayName("Should delete goal successfully when user is owner")
+    void shouldDeleteGoalSuccessfully() {
+        UUID userId = UUID.randomUUID();
+        UUID goalId = UUID.randomUUID();
+
+        doNothing().when(goalServicePort).delete(goalId, userId);
+
+        ResponseEntity<Void> result = goalController.deleteGoal(userId.toString(), goalId);
+
+        assertEquals(HttpStatus.NO_CONTENT, result.getStatusCode());
+        verify(goalServicePort).delete(goalId, userId);
+    }
+
+    @Test
+    @DisplayName("Should add deposit successfully")
+    void shouldAddDepositSuccessfully() {
+        UUID userId = UUID.randomUUID();
+        UUID goalId = UUID.randomUUID();
+        GoalDepositRequest request = GoalDepositRequest.builder()
+                .depositAmount(BigDecimal.valueOf(500))
+                .depositDate(LocalDate.now())
+                .build();
+        GoalDeposit deposit = new GoalDeposit();
+        GoalDeposit savedDeposit = GoalDeposit.builder()
+                .id(UUID.randomUUID())
+                .goalId(goalId)
+                .build();
+        GoalDepositResponse response = new GoalDepositResponse();
+
+        when(goalDepositMapper.toDomain(request, goalId)).thenReturn(deposit);
+        when(goalDepositServicePort.create(deposit, userId)).thenReturn(savedDeposit);
+        when(goalDepositMapper.toResponse(savedDeposit)).thenReturn(response);
+
+        ResponseEntity<GoalDepositResponse> result = goalController.addDeposit(userId.toString(), goalId, request);
+
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertEquals(response, result.getBody());
+        verify(goalDepositServicePort).create(deposit, userId);
+    }
+
+    @Test
+    @DisplayName("Should get deposits successfully")
+    void shouldGetDepositsSuccessfully() {
+        UUID userId = UUID.randomUUID();
+        UUID goalId = UUID.randomUUID();
+        List<GoalDeposit> deposits = List.of(
+            GoalDeposit.builder().depositAmount(BigDecimal.valueOf(100)).build(),
+            GoalDeposit.builder().depositAmount(BigDecimal.valueOf(200)).build()
+        );
+        List<GoalDepositResponse> responses = List.of(
+            new GoalDepositResponse(),
+            new GoalDepositResponse()
+        );
+
+        when(goalDepositServicePort.findAllByGoalId(goalId, userId)).thenReturn(deposits);
+        when(goalDepositMapper.toResponseList(deposits)).thenReturn(responses);
+
+        ResponseEntity<List<GoalDepositResponse>> result = goalController.getDeposits(userId.toString(), goalId);
+
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertEquals(responses, result.getBody());
+        assertEquals(2, result.getBody().size());
+    }
+
+    @Test
+    @DisplayName("Should delete deposit successfully")
+    void shouldDeleteDepositSuccessfully() {
+        UUID userId = UUID.randomUUID();
+        UUID goalId = UUID.randomUUID();
+        UUID depositId = UUID.randomUUID();
+
+        doNothing().when(goalDepositServicePort).delete(goalId, depositId, userId);
+
+        ResponseEntity<Void> result = goalController.deleteDeposit(userId.toString(), goalId, depositId);
+
+        assertEquals(HttpStatus.NO_CONTENT, result.getStatusCode());
+        verify(goalDepositServicePort).delete(goalId, depositId, userId);
+    }
+
+    @Test
+    @DisplayName("Should return empty list when user has no goals")
+    void shouldReturnEmptyListWhenNoGoals() {
+        String userId = UUID.randomUUID().toString();
+
+        when(goalServicePort.findAllByProfileId(UUID.fromString(userId))).thenReturn(List.of());
+        when(goalMapper.toResponseList(List.of())).thenReturn(List.of());
+
+        ResponseEntity<List<GoalResponse>> result = goalController.getGoals(userId);
+
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertTrue(result.getBody().isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should return empty list when goal has no deposits")
+    void shouldReturnEmptyListWhenNoDeposits() {
+        UUID userId = UUID.randomUUID();
+        UUID goalId = UUID.randomUUID();
+
+        when(goalDepositServicePort.findAllByGoalId(goalId, userId)).thenReturn(List.of());
+        when(goalDepositMapper.toResponseList(List.of())).thenReturn(List.of());
+
+        ResponseEntity<List<GoalDepositResponse>> result = goalController.getDeposits(userId.toString(), goalId);
+
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertTrue(result.getBody().isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should create goal with target date")
+    void shouldCreateGoalWithTargetDate() {
+        String userId = UUID.randomUUID().toString();
+        LocalDate targetDate = LocalDate.now().plusYears(1);
+        GoalRequest request = GoalRequest.builder()
+                .name("Long-term Goal")
+                .goalAmount(BigDecimal.valueOf(50000))
+                .targetDate(targetDate)
+                .build();
+        Goal goal = Goal.builder().targetDate(targetDate).build();
+        Goal savedGoal = Goal.builder()
+                .id(UUID.randomUUID())
+                .targetDate(targetDate)
+                .build();
+        GoalResponse response = new GoalResponse();
+
+        when(goalMapper.toDomain(eq(request), any(UUID.class))).thenReturn(goal);
+        when(goalServicePort.create(goal)).thenReturn(savedGoal);
+        when(goalMapper.toResponse(savedGoal)).thenReturn(response);
+
+        ResponseEntity<GoalResponse> result = goalController.createGoal(userId, request);
+
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        verify(goalServicePort).create(goal);
+    }
+
+    @Test
+    @DisplayName("Should update goal marking as completed")
+    void shouldUpdateGoalMarkingAsCompleted() {
+        UUID userId = UUID.randomUUID();
+        UUID goalId = UUID.randomUUID();
+        LocalDate completedDate = LocalDate.now();
+        GoalUpdateRequest request = GoalUpdateRequest.builder()
+                .completedAt(completedDate)
+                .build();
+        Goal goal = Goal.builder()
+                .id(goalId)
+                .profileId(userId)
+                .build();
+        GoalResponse response = new GoalResponse();
+
+        when(goalServicePort.findByIdAndProfileId(goalId, userId)).thenReturn(goal);
+        doNothing().when(goalMapper).updateDomainFromDto(eq(request), eq(goal));
+        when(goalServicePort.update(goal)).thenReturn(goal);
+        when(goalMapper.toResponse(goal)).thenReturn(response);
+
+        ResponseEntity<GoalResponse> result = goalController.updateGoal(userId.toString(), goalId, request);
+
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        verify(goalMapper).updateDomainFromDto(request, goal);
+    }
+
+    @Test
+    @DisplayName("Should add deposit with past date")
+    void shouldAddDepositWithPastDate() {
+        UUID userId = UUID.randomUUID();
+        UUID goalId = UUID.randomUUID();
+        LocalDate pastDate = LocalDate.now().minusDays(30);
+        
+        GoalDepositRequest request = GoalDepositRequest.builder()
+                .depositAmount(BigDecimal.valueOf(100))
+                .depositDate(pastDate)
+                .build();
+
+        GoalDeposit deposit = new GoalDeposit();
+        GoalDeposit savedDeposit = GoalDeposit.builder()
+                .id(UUID.randomUUID())
+                .depositDate(pastDate)
+                .build();
+        GoalDepositResponse response = new GoalDepositResponse();
+
+        when(goalDepositMapper.toDomain(request, goalId)).thenReturn(deposit);
+        when(goalDepositServicePort.create(deposit, userId)).thenReturn(savedDeposit);
+        when(goalDepositMapper.toResponse(savedDeposit)).thenReturn(response);
+
+        ResponseEntity<GoalDepositResponse> result = goalController.addDeposit(userId.toString(), goalId, request);
+
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        verify(goalDepositServicePort).create(deposit, userId);
+    }
+}


### PR DESCRIPTION
**Objetivo:**
Implementar o sistema completo de gerenciamento de metas financeiras com operações CRUD e funcionalidades de depósitos.

**O que foi feito:**
- Criadas as entidades Goal e GoalDeposit seguindo a arquitetura hexagonal do projeto
- Implementados modelos de domínio, entidades JPA, adapters de repositório e serviços de negócio
- Adicionadas migrations Flyway para criação das tabelas goals e goal_deposits no PostgreSQL
- Desenvolvidos 8 endpoints REST documentados com Swagger para gerenciar metas e depósitos
- Criados DTOs de requisição e resposta com validações Bean Validation
- Implementados mappers MapStruct para conversão entre camadas
- Adicionadas validações de propriedade de recursos e tratamento de exceções

**Testes:**
- [x] Testes unitários
- [x] Testes manuais

**Extra:**
Esta implementação contempla os requisitos 7.1 (#25) e 7.2 (#26) conforme especificação do projeto.