### PR TITLE
[Backend][core-service] Implementação da funcionalidade para upload/remoção de comprovantes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       retries: 5
 
   minio:
-    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
     container_name: poupeai-minio
     restart: unless-stopped
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
-  postgres:
+  core-db:
     image: postgres:16-alpine
-    container_name: poupeai-postgres
+    container_name: core-db-local
     restart: unless-stopped
     environment:
       POSTGRES_USER: postgres
@@ -14,13 +14,31 @@ services:
     networks:
       - poupeai-network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres -d poupeai_core"]
+      test: [ "CMD-SHELL", "pg_isready -U postgres -d core_db" ]
       interval: 5s
       timeout: 5s
       retries: 5
 
+  minio:
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    container_name: poupeai-minio
+    restart: unless-stopped
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    volumes:
+      - minio_data:/data
+    command: server /data --console-address ":9001"
+    networks:
+      - poupeai-network
+
 volumes:
   postgres_data:
+  minio_data:
+
 
 networks:
   poupeai-network:

--- a/poupeai-core-application/src/main/resources/application.properties
+++ b/poupeai-core-application/src/main/resources/application.properties
@@ -25,3 +25,13 @@ spring.flyway.baseline-on-migrate=true
 # Security / OAuth2 Configuration
 spring.security.oauth2.resourceserver.jwt.issuer-uri=${KEYCLOAK_URL:http://localhost:8080}/realms/${KEYCLOAK_REALM:poupe-ai}
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${KEYCLOAK_URL:http://localhost:8080}/realms/${KEYCLOAK_REALM:poupe-ai}/protocol/openid-connect/certs
+
+# MinIO Configuration
+minio.endpoint=${MINIO_ENDPOINT:http://localhost:9000}
+minio.access-key=${MINIO_ACCESS_KEY:minioadmin}
+minio.secret-key=${MINIO_SECRET_KEY:minioadmin}
+minio.bucket-name=${MINIO_BUCKET:poupeai-receipts}
+
+# File Upload Configuration
+spring.servlet.multipart.max-file-size=5MB
+spring.servlet.multipart.max-request-size=5MB

--- a/poupeai-core-business/src/main/java/io/github/poupeai/core/business/adapter/TransactionServiceAdapter.java
+++ b/poupeai-core-business/src/main/java/io/github/poupeai/core/business/adapter/TransactionServiceAdapter.java
@@ -126,6 +126,10 @@ public class TransactionServiceAdapter implements TransactionServicePort {
 
         UUID invoiceId = transaction.getInvoiceId();
 
+        if (transaction.getAttachmentKey() != null) {
+            storagePort.delete(transaction.getAttachmentKey());
+        }
+
         if (Boolean.TRUE.equals(transaction.getIsInstallment()) && transaction.getPurchaseGroupUuid() != null) {
             transactionRepositoryPort.deleteByPurchaseGroupUuid(transaction.getPurchaseGroupUuid());
         } else {
@@ -293,6 +297,10 @@ public class TransactionServiceAdapter implements TransactionServicePort {
 
         Transaction transaction = findByIdAndProfileId(id, profileId);
 
+        if (transaction.getAttachmentKey() != null) {
+            storagePort.delete(transaction.getAttachmentKey());
+        }
+
         String attachmentKey = UUID.randomUUID().toString();
 
         Map<String, String> tags = Map.of(
@@ -301,6 +309,20 @@ public class TransactionServiceAdapter implements TransactionServicePort {
         storagePort.upload(attachmentKey, content, contentType, size, tags);
 
         transaction.setAttachmentKey(attachmentKey);
+        return transactionRepositoryPort.update(transaction);
+    }
+
+    @Override
+    @Transactional
+    public Transaction deleteReceipt(UUID id, UUID profileId) {
+        Transaction transaction = findByIdAndProfileId(id, profileId);
+
+        if (transaction.getAttachmentKey() == null) {
+            throw new DomainException("Esta transação não possui comprovante.");
+        }
+
+        storagePort.delete(transaction.getAttachmentKey());
+        transaction.setAttachmentKey(null);
         return transactionRepositoryPort.update(transaction);
     }
 }

--- a/poupeai-core-business/src/main/java/io/github/poupeai/core/business/adapter/TransactionServiceAdapter.java
+++ b/poupeai-core-business/src/main/java/io/github/poupeai/core/business/adapter/TransactionServiceAdapter.java
@@ -10,6 +10,7 @@ import io.github.poupeai.core.domain.model.Transaction;
 import io.github.poupeai.core.domain.model.TransactionType;
 import io.github.poupeai.core.domain.port.business.InvoiceServicePort;
 import io.github.poupeai.core.domain.port.business.TransactionServicePort;
+import io.github.poupeai.core.domain.port.output.StoragePort;
 import io.github.poupeai.core.domain.port.persistence.BankAccountRepositoryPort;
 import io.github.poupeai.core.domain.port.persistence.CategoryRepositoryPort;
 import io.github.poupeai.core.domain.port.persistence.CreditCardRepositoryPort;
@@ -18,12 +19,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.InputStream;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.Map;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -33,6 +37,7 @@ public class TransactionServiceAdapter implements TransactionServicePort {
     private final CreditCardRepositoryPort creditCardRepositoryPort;
     private final CategoryRepositoryPort categoryRepositoryPort;
     private final InvoiceServicePort invoiceServicePort;
+    private final StoragePort storagePort;
 
     @Override
     @Transactional
@@ -40,9 +45,9 @@ public class TransactionServiceAdapter implements TransactionServicePort {
         validateTransaction(transaction);
 
         Category category = categoryRepositoryPort.findByIdAndProfileId(
-                transaction.getCategoryId(), transaction.getProfileId()
-        ).orElseThrow(() -> new ResourceNotFoundException("Categoria não encontrada."));
-        
+                transaction.getCategoryId(), transaction.getProfileId())
+                .orElseThrow(() -> new ResourceNotFoundException("Categoria não encontrada."));
+
         TransactionType derivedType = mapCategoryTypeToTransactionType(category.getType());
         transaction.setType(derivedType);
 
@@ -55,7 +60,7 @@ public class TransactionServiceAdapter implements TransactionServicePort {
 
         return transactionRepositoryPort.create(transaction);
     }
-    
+
     private TransactionType mapCategoryTypeToTransactionType(CategoryType categoryType) {
         return switch (categoryType) {
             case INCOME -> TransactionType.INCOME;
@@ -70,12 +75,14 @@ public class TransactionServiceAdapter implements TransactionServicePort {
                 .orElseThrow(() -> new ResourceNotFoundException("Transação não encontrada."));
 
         if (Boolean.TRUE.equals(existingTransaction.getIsInstallment())) {
-            throw new DomainException("Não é possível editar uma transação parcelada. Delete todas as parcelas e crie novamente.");
+            throw new DomainException(
+                    "Não é possível editar uma transação parcelada. Delete todas as parcelas e crie novamente.");
         }
 
         validateTransactionForUpdate(transaction, existingTransaction);
 
-        UUID categoryId = transaction.getCategoryId() != null ? transaction.getCategoryId() : existingTransaction.getCategoryId();
+        UUID categoryId = transaction.getCategoryId() != null ? transaction.getCategoryId()
+                : existingTransaction.getCategoryId();
         Category category = categoryRepositoryPort.findByIdAndProfileId(categoryId, profileId)
                 .orElseThrow(() -> new ResourceNotFoundException("Categoria não encontrada."));
         TransactionType derivedType = mapCategoryTypeToTransactionType(category.getType());
@@ -132,12 +139,12 @@ public class TransactionServiceAdapter implements TransactionServicePort {
 
     private Transaction createCreditCardTransaction(Transaction transaction) {
         CreditCard creditCard = creditCardRepositoryPort.findByIdAndProfileId(
-                transaction.getCreditCardId(), transaction.getProfileId()
-        ).orElseThrow(() -> new ResourceNotFoundException("Cartão de crédito não encontrado."));
+                transaction.getCreditCardId(), transaction.getProfileId())
+                .orElseThrow(() -> new ResourceNotFoundException("Cartão de crédito não encontrado."));
 
-        if (Boolean.TRUE.equals(transaction.getIsInstallment()) && 
-            transaction.getTotalInstallments() != null && 
-            transaction.getTotalInstallments() > 1) {
+        if (Boolean.TRUE.equals(transaction.getIsInstallment()) &&
+                transaction.getTotalInstallments() != null &&
+                transaction.getTotalInstallments() > 1) {
             return createInstallmentTransactions(transaction, creditCard);
         }
 
@@ -145,7 +152,7 @@ public class TransactionServiceAdapter implements TransactionServicePort {
         transaction.setInvoiceId(invoice.getId());
 
         Transaction savedTransaction = transactionRepositoryPort.create(transaction);
-        
+
         invoiceServicePort.updateInvoiceTotals(invoice.getId());
 
         return savedTransaction;
@@ -155,12 +162,10 @@ public class TransactionServiceAdapter implements TransactionServicePort {
         int totalInstallments = transaction.getTotalInstallments();
         BigDecimal totalAmount = transaction.getAmount();
         BigDecimal installmentAmount = totalAmount.divide(
-                BigDecimal.valueOf(totalInstallments), 2, RoundingMode.HALF_UP
-        );
-        
+                BigDecimal.valueOf(totalInstallments), 2, RoundingMode.HALF_UP);
+
         BigDecimal remainder = totalAmount.subtract(
-                installmentAmount.multiply(BigDecimal.valueOf(totalInstallments))
-        );
+                installmentAmount.multiply(BigDecimal.valueOf(totalInstallments)));
 
         UUID purchaseGroupUuid = UUID.randomUUID();
         LocalDate currentDate = transaction.getTransactionDate();
@@ -169,7 +174,7 @@ public class TransactionServiceAdapter implements TransactionServicePort {
 
         for (int i = 1; i <= totalInstallments; i++) {
             Invoice invoice = invoiceServicePort.getOrCreateInvoiceForDate(creditCard, currentDate);
-            
+
             BigDecimal currentInstallmentAmount = installmentAmount;
             if (i == totalInstallments && remainder.compareTo(BigDecimal.ZERO) != 0) {
                 currentInstallmentAmount = installmentAmount.add(remainder);
@@ -195,7 +200,7 @@ public class TransactionServiceAdapter implements TransactionServicePort {
                     .build();
 
             installments.add(installment);
-            
+
             if (!invoiceIdsToUpdate.contains(invoice.getId())) {
                 invoiceIdsToUpdate.add(invoice.getId());
             }
@@ -234,11 +239,13 @@ public class TransactionServiceAdapter implements TransactionServicePort {
         }
 
         if (transaction.getBankAccountId() != null && transaction.getCreditCardId() != null) {
-            throw new DomainException("A transação não pode estar associada a uma conta bancária e cartão de crédito simultaneamente.");
+            throw new DomainException(
+                    "A transação não pode estar associada a uma conta bancária e cartão de crédito simultaneamente.");
         }
 
         if (transaction.getBankAccountId() != null) {
-            if (!bankAccountRepositoryPort.existsByIdAndProfileId(transaction.getBankAccountId(), transaction.getProfileId())) {
+            if (!bankAccountRepositoryPort.existsByIdAndProfileId(transaction.getBankAccountId(),
+                    transaction.getProfileId())) {
                 throw new ResourceNotFoundException("Conta bancária não encontrada.");
             }
         }
@@ -262,15 +269,38 @@ public class TransactionServiceAdapter implements TransactionServicePort {
             throw new DomainException("O valor da transação deve ser maior que zero.");
         }
 
-        String description = transaction.getDescription() != null ? transaction.getDescription() : existingTransaction.getDescription();
+        String description = transaction.getDescription() != null ? transaction.getDescription()
+                : existingTransaction.getDescription();
         if (description == null || description.trim().isEmpty()) {
             throw new DomainException("A descrição da transação é obrigatória.");
         }
 
         if (transaction.getCategoryId() != null) {
-            if (!categoryRepositoryPort.existsByIdAndProfileId(transaction.getCategoryId(), existingTransaction.getProfileId())) {
+            if (!categoryRepositoryPort.existsByIdAndProfileId(transaction.getCategoryId(),
+                    existingTransaction.getProfileId())) {
                 throw new ResourceNotFoundException("Categoria não encontrada.");
             }
         }
+    }
+
+    @Override
+    @Transactional
+    public Transaction uploadReceipt(UUID id, UUID profileId, InputStream content, String contentType, long size) {
+        Set<String> allowedTypes = Set.of("image/jpeg", "image/jpg", "image/png", "application/pdf");
+        if (contentType == null || !allowedTypes.contains(contentType.toLowerCase())) {
+            throw new DomainException("Tipo de arquivo não permitido. Tipos aceitos: JPG, JPEG, PNG, PDF.");
+        }
+
+        Transaction transaction = findByIdAndProfileId(id, profileId);
+
+        String attachmentKey = UUID.randomUUID().toString();
+
+        Map<String, String> tags = Map.of(
+                "transactionId", id.toString(),
+                "profileId", profileId.toString());
+        storagePort.upload(attachmentKey, content, contentType, size, tags);
+
+        transaction.setAttachmentKey(attachmentKey);
+        return transactionRepositoryPort.update(transaction);
     }
 }

--- a/poupeai-core-business/src/test/java/io/github/poupeai/core/business/adapter/TransactionServiceAdapterTest.java
+++ b/poupeai-core-business/src/test/java/io/github/poupeai/core/business/adapter/TransactionServiceAdapterTest.java
@@ -736,5 +736,91 @@ class TransactionServiceAdapterTest {
                                         () -> transactionServiceAdapter.uploadReceipt(
                                                         transactionId, profileId, content, "image/png", 10L));
                 }
+
+                @Test
+                @DisplayName("Should delete old attachment when replacing receipt")
+                void shouldDeleteOldAttachmentWhenReplacingReceipt() {
+                        UUID profileId = UUID.randomUUID();
+                        UUID transactionId = UUID.randomUUID();
+                        String oldAttachmentKey = "old-attachment-key";
+                        Transaction transaction = Transaction.builder()
+                                        .id(transactionId)
+                                        .profileId(profileId)
+                                        .attachmentKey(oldAttachmentKey)
+                                        .build();
+
+                        when(transactionRepositoryPort.findByIdAndProfileId(transactionId, profileId))
+                                        .thenReturn(Optional.of(transaction));
+                        when(transactionRepositoryPort.update(any())).thenAnswer(inv -> inv.getArgument(0));
+
+                        java.io.InputStream content = new java.io.ByteArrayInputStream("new image".getBytes());
+                        transactionServiceAdapter.uploadReceipt(
+                                        transactionId, profileId, content, "image/jpeg", 10L);
+
+                        verify(storagePort).delete(oldAttachmentKey);
+                        verify(storagePort).upload(anyString(), any(), eq("image/jpeg"), eq(10L), any());
+                }
+        }
+
+        @Nested
+        @DisplayName("Delete Receipt Tests")
+        class DeleteReceiptTests {
+
+                @Test
+                @DisplayName("Should delete receipt successfully")
+                void shouldDeleteReceiptSuccessfully() {
+                        UUID profileId = UUID.randomUUID();
+                        UUID transactionId = UUID.randomUUID();
+                        String attachmentKey = "test-attachment-key";
+                        Transaction transaction = Transaction.builder()
+                                        .id(transactionId)
+                                        .profileId(profileId)
+                                        .attachmentKey(attachmentKey)
+                                        .build();
+
+                        when(transactionRepositoryPort.findByIdAndProfileId(transactionId, profileId))
+                                        .thenReturn(Optional.of(transaction));
+                        when(transactionRepositoryPort.update(any())).thenAnswer(inv -> inv.getArgument(0));
+
+                        Transaction result = transactionServiceAdapter.deleteReceipt(transactionId, profileId);
+
+                        assertNull(result.getAttachmentKey());
+                        verify(storagePort).delete(attachmentKey);
+                        verify(transactionRepositoryPort).update(any());
+                }
+
+                @Test
+                @DisplayName("Should throw exception when no receipt exists")
+                void shouldThrowExceptionWhenNoReceiptExists() {
+                        UUID profileId = UUID.randomUUID();
+                        UUID transactionId = UUID.randomUUID();
+                        Transaction transaction = Transaction.builder()
+                                        .id(transactionId)
+                                        .profileId(profileId)
+                                        .attachmentKey(null)
+                                        .build();
+
+                        when(transactionRepositoryPort.findByIdAndProfileId(transactionId, profileId))
+                                        .thenReturn(Optional.of(transaction));
+
+                        DomainException exception = assertThrows(DomainException.class,
+                                        () -> transactionServiceAdapter.deleteReceipt(transactionId, profileId));
+
+                        assertEquals("Esta transação não possui comprovante.", exception.getMessage());
+                        verify(storagePort, never()).delete(any());
+                }
+
+                @Test
+                @DisplayName("Should throw exception when transaction not found")
+                void shouldThrowExceptionWhenTransactionNotFoundForDelete() {
+                        UUID profileId = UUID.randomUUID();
+                        UUID transactionId = UUID.randomUUID();
+
+                        when(transactionRepositoryPort.findByIdAndProfileId(transactionId, profileId))
+                                        .thenReturn(Optional.empty());
+
+                        assertThrows(ResourceNotFoundException.class,
+                                        () -> transactionServiceAdapter.deleteReceipt(transactionId, profileId));
+                }
         }
 }

--- a/poupeai-core-business/src/test/java/io/github/poupeai/core/business/adapter/TransactionServiceAdapterTest.java
+++ b/poupeai-core-business/src/test/java/io/github/poupeai/core/business/adapter/TransactionServiceAdapterTest.java
@@ -14,6 +14,7 @@ import io.github.poupeai.core.domain.port.persistence.BankAccountRepositoryPort;
 import io.github.poupeai.core.domain.port.persistence.CategoryRepositoryPort;
 import io.github.poupeai.core.domain.port.persistence.CreditCardRepositoryPort;
 import io.github.poupeai.core.domain.port.persistence.TransactionRepositoryPort;
+import io.github.poupeai.core.domain.port.output.StoragePort;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -37,593 +38,703 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class TransactionServiceAdapterTest {
 
-    @Mock
-    private TransactionRepositoryPort transactionRepositoryPort;
+        @Mock
+        private TransactionRepositoryPort transactionRepositoryPort;
 
-    @Mock
-    private BankAccountRepositoryPort bankAccountRepositoryPort;
+        @Mock
+        private BankAccountRepositoryPort bankAccountRepositoryPort;
 
-    @Mock
-    private CreditCardRepositoryPort creditCardRepositoryPort;
+        @Mock
+        private CreditCardRepositoryPort creditCardRepositoryPort;
 
-    @Mock
-    private CategoryRepositoryPort categoryRepositoryPort;
+        @Mock
+        private CategoryRepositoryPort categoryRepositoryPort;
 
-    @Mock
-    private InvoiceServicePort invoiceServicePort;
+        @Mock
+        private InvoiceServicePort invoiceServicePort;
 
-    @InjectMocks
-    private TransactionServiceAdapter transactionServiceAdapter;
+        @Mock
+        private StoragePort storagePort;
 
-    @Nested
-    @DisplayName("Create Transaction Tests")
-    class CreateTransactionTests {
+        @InjectMocks
+        private TransactionServiceAdapter transactionServiceAdapter;
 
-        @Test
-        @DisplayName("Should create bank account transaction successfully")
-        void shouldCreateBankAccountTransactionSuccessfully() {
-            UUID profileId = UUID.randomUUID();
-            UUID bankAccountId = UUID.randomUUID();
-            UUID categoryId = UUID.randomUUID();
-            Category category = createCategory(categoryId, profileId, CategoryType.EXPENSE);
-            Transaction transaction = createBankAccountTransaction(profileId, bankAccountId, categoryId);
+        @Nested
+        @DisplayName("Create Transaction Tests")
+        class CreateTransactionTests {
 
-            when(bankAccountRepositoryPort.existsByIdAndProfileId(bankAccountId, profileId)).thenReturn(true);
-            when(categoryRepositoryPort.findByIdAndProfileId(categoryId, profileId)).thenReturn(Optional.of(category));
-            when(transactionRepositoryPort.create(any())).thenReturn(transaction);
+                @Test
+                @DisplayName("Should create bank account transaction successfully")
+                void shouldCreateBankAccountTransactionSuccessfully() {
+                        UUID profileId = UUID.randomUUID();
+                        UUID bankAccountId = UUID.randomUUID();
+                        UUID categoryId = UUID.randomUUID();
+                        Category category = createCategory(categoryId, profileId, CategoryType.EXPENSE);
+                        Transaction transaction = createBankAccountTransaction(profileId, bankAccountId, categoryId);
 
-            Transaction result = transactionServiceAdapter.create(transaction);
+                        when(bankAccountRepositoryPort.existsByIdAndProfileId(bankAccountId, profileId))
+                                        .thenReturn(true);
+                        when(categoryRepositoryPort.findByIdAndProfileId(categoryId, profileId))
+                                        .thenReturn(Optional.of(category));
+                        when(transactionRepositoryPort.create(any())).thenReturn(transaction);
 
-            assertNotNull(result);
-            assertEquals(transaction.getDescription(), result.getDescription());
-            assertEquals(TransactionType.EXPENSE, result.getType());
-            verify(transactionRepositoryPort).create(any());
+                        Transaction result = transactionServiceAdapter.create(transaction);
+
+                        assertNotNull(result);
+                        assertEquals(transaction.getDescription(), result.getDescription());
+                        assertEquals(TransactionType.EXPENSE, result.getType());
+                        verify(transactionRepositoryPort).create(any());
+                }
+
+                @Test
+                @DisplayName("Should create credit card transaction with automatic invoice creation")
+                void shouldCreateCreditCardTransactionWithInvoice() {
+                        UUID profileId = UUID.randomUUID();
+                        UUID creditCardId = UUID.randomUUID();
+                        UUID invoiceId = UUID.randomUUID();
+                        UUID categoryId = UUID.randomUUID();
+                        Category category = createCategory(categoryId, profileId, CategoryType.EXPENSE);
+                        Transaction transaction = createCreditCardTransaction(profileId, creditCardId, categoryId);
+                        CreditCard creditCard = createCreditCard(creditCardId, profileId);
+                        Invoice invoice = createInvoice(invoiceId, creditCardId);
+
+                        when(categoryRepositoryPort.findByIdAndProfileId(categoryId, profileId))
+                                        .thenReturn(Optional.of(category));
+                        when(creditCardRepositoryPort.findByIdAndProfileId(creditCardId, profileId))
+                                        .thenReturn(Optional.of(creditCard));
+                        when(invoiceServicePort.getOrCreateInvoiceForDate(any(), any())).thenReturn(invoice);
+                        when(transactionRepositoryPort.create(any())).thenAnswer(inv -> {
+                                Transaction t = inv.getArgument(0);
+                                t.setId(UUID.randomUUID());
+                                return t;
+                        });
+
+                        Transaction result = transactionServiceAdapter.create(transaction);
+
+                        assertNotNull(result);
+                        assertEquals(invoiceId, result.getInvoiceId());
+                        assertEquals(TransactionType.EXPENSE, result.getType());
+                        verify(invoiceServicePort).updateInvoiceTotals(invoiceId);
+                }
+
+                @Test
+                @DisplayName("Should create installment transactions correctly")
+                void shouldCreateInstallmentTransactions() {
+                        UUID profileId = UUID.randomUUID();
+                        UUID creditCardId = UUID.randomUUID();
+                        UUID categoryId = UUID.randomUUID();
+                        Category category = createCategory(categoryId, profileId, CategoryType.EXPENSE);
+                        Transaction transaction = createInstallmentTransaction(profileId, creditCardId, categoryId, 3);
+                        CreditCard creditCard = createCreditCard(creditCardId, profileId);
+
+                        when(categoryRepositoryPort.findByIdAndProfileId(categoryId, profileId))
+                                        .thenReturn(Optional.of(category));
+                        when(creditCardRepositoryPort.findByIdAndProfileId(creditCardId, profileId))
+                                        .thenReturn(Optional.of(creditCard));
+                        when(invoiceServicePort.getOrCreateInvoiceForDate(any(), any()))
+                                        .thenAnswer(inv -> createInvoice(UUID.randomUUID(), creditCardId));
+                        when(transactionRepositoryPort.createAll(anyList())).thenAnswer(inv -> {
+                                List<Transaction> transactions = inv.getArgument(0);
+                                transactions.forEach(t -> t.setId(UUID.randomUUID()));
+                                return transactions;
+                        });
+
+                        Transaction result = transactionServiceAdapter.create(transaction);
+
+                        assertNotNull(result);
+                        assertTrue(result.getIsInstallment());
+
+                        ArgumentCaptor<List<Transaction>> captor = ArgumentCaptor.forClass(List.class);
+                        verify(transactionRepositoryPort).createAll(captor.capture());
+                        List<Transaction> installments = captor.getValue();
+
+                        assertEquals(3, installments.size());
+                        assertEquals(1, installments.get(0).getInstallmentNumber());
+                        assertEquals(2, installments.get(1).getInstallmentNumber());
+                        assertEquals(3, installments.get(2).getInstallmentNumber());
+                }
+
+                @Test
+                @DisplayName("Should throw exception when amount is zero or negative")
+                void shouldThrowExceptionWhenAmountIsInvalid() {
+                        UUID profileId = UUID.randomUUID();
+                        Transaction transaction = Transaction.builder()
+                                        .profileId(profileId)
+                                        .description("Test")
+                                        .amount(BigDecimal.ZERO)
+                                        .transactionDate(LocalDate.now())
+                                        .bankAccountId(UUID.randomUUID())
+                                        .categoryId(UUID.randomUUID())
+                                        .build();
+
+                        assertThrows(DomainException.class, () -> transactionServiceAdapter.create(transaction));
+                }
+
+                @Test
+                @DisplayName("Should throw exception when description is empty")
+                void shouldThrowExceptionWhenDescriptionIsEmpty() {
+                        UUID profileId = UUID.randomUUID();
+                        Transaction transaction = Transaction.builder()
+                                        .profileId(profileId)
+                                        .description("")
+                                        .amount(BigDecimal.valueOf(100))
+                                        .transactionDate(LocalDate.now())
+                                        .bankAccountId(UUID.randomUUID())
+                                        .categoryId(UUID.randomUUID())
+                                        .build();
+
+                        assertThrows(DomainException.class, () -> transactionServiceAdapter.create(transaction));
+                }
+
+                @Test
+                @DisplayName("Should throw exception when neither bank account nor credit card is provided")
+                void shouldThrowExceptionWhenNoPaymentMethodProvided() {
+                        UUID profileId = UUID.randomUUID();
+                        Transaction transaction = Transaction.builder()
+                                        .profileId(profileId)
+                                        .description("Test")
+                                        .amount(BigDecimal.valueOf(100))
+                                        .transactionDate(LocalDate.now())
+                                        .categoryId(UUID.randomUUID())
+                                        .build();
+
+                        assertThrows(DomainException.class, () -> transactionServiceAdapter.create(transaction));
+                }
+
+                @Test
+                @DisplayName("Should throw exception when both bank account and credit card are provided")
+                void shouldThrowExceptionWhenBothPaymentMethodsProvided() {
+                        UUID profileId = UUID.randomUUID();
+                        Transaction transaction = Transaction.builder()
+                                        .profileId(profileId)
+                                        .description("Test")
+                                        .amount(BigDecimal.valueOf(100))
+                                        .transactionDate(LocalDate.now())
+                                        .bankAccountId(UUID.randomUUID())
+                                        .creditCardId(UUID.randomUUID())
+                                        .categoryId(UUID.randomUUID())
+                                        .build();
+
+                        assertThrows(DomainException.class, () -> transactionServiceAdapter.create(transaction));
+                }
+
+                @Test
+                @DisplayName("Should throw exception when bank account not found")
+                void shouldThrowExceptionWhenBankAccountNotFound() {
+                        UUID profileId = UUID.randomUUID();
+                        UUID bankAccountId = UUID.randomUUID();
+                        UUID categoryId = UUID.randomUUID();
+                        Transaction transaction = createBankAccountTransaction(profileId, bankAccountId, categoryId);
+
+                        when(bankAccountRepositoryPort.existsByIdAndProfileId(bankAccountId, profileId))
+                                        .thenReturn(false);
+
+                        assertThrows(ResourceNotFoundException.class,
+                                        () -> transactionServiceAdapter.create(transaction));
+                }
+
+                @Test
+                @DisplayName("Should throw exception when credit card not found")
+                void shouldThrowExceptionWhenCreditCardNotFound() {
+                        UUID profileId = UUID.randomUUID();
+                        UUID creditCardId = UUID.randomUUID();
+                        UUID categoryId = UUID.randomUUID();
+                        Category category = createCategory(categoryId, profileId, CategoryType.EXPENSE);
+                        Transaction transaction = createCreditCardTransaction(profileId, creditCardId, categoryId);
+
+                        when(categoryRepositoryPort.findByIdAndProfileId(categoryId, profileId))
+                                        .thenReturn(Optional.of(category));
+                        when(creditCardRepositoryPort.findByIdAndProfileId(creditCardId, profileId))
+                                        .thenReturn(Optional.empty());
+
+                        assertThrows(ResourceNotFoundException.class,
+                                        () -> transactionServiceAdapter.create(transaction));
+                }
+
+                @Test
+                @DisplayName("Should throw exception when installment count is less than 2")
+                void shouldThrowExceptionWhenInstallmentCountInvalid() {
+                        UUID profileId = UUID.randomUUID();
+                        Transaction transaction = Transaction.builder()
+                                        .profileId(profileId)
+                                        .description("Test")
+                                        .amount(BigDecimal.valueOf(100))
+                                        .transactionDate(LocalDate.now())
+                                        .creditCardId(UUID.randomUUID())
+                                        .categoryId(UUID.randomUUID())
+                                        .isInstallment(true)
+                                        .totalInstallments(1)
+                                        .build();
+
+                        assertThrows(DomainException.class, () -> transactionServiceAdapter.create(transaction));
+                }
+
+                @Test
+                @DisplayName("Should throw exception when installment count exceeds 48")
+                void shouldThrowExceptionWhenInstallmentCountExceedsMax() {
+                        UUID profileId = UUID.randomUUID();
+                        Transaction transaction = Transaction.builder()
+                                        .profileId(profileId)
+                                        .description("Test")
+                                        .amount(BigDecimal.valueOf(100))
+                                        .transactionDate(LocalDate.now())
+                                        .creditCardId(UUID.randomUUID())
+                                        .categoryId(UUID.randomUUID())
+                                        .isInstallment(true)
+                                        .totalInstallments(49)
+                                        .build();
+
+                        assertThrows(DomainException.class, () -> transactionServiceAdapter.create(transaction));
+                }
+
+                @Test
+                @DisplayName("Should throw exception when trying to create installment with bank account")
+                void shouldThrowExceptionWhenInstallmentWithBankAccount() {
+                        UUID profileId = UUID.randomUUID();
+                        UUID bankAccountId = UUID.randomUUID();
+                        Transaction transaction = Transaction.builder()
+                                        .profileId(profileId)
+                                        .description("Test")
+                                        .amount(BigDecimal.valueOf(100))
+                                        .transactionDate(LocalDate.now())
+                                        .bankAccountId(bankAccountId)
+                                        .categoryId(UUID.randomUUID())
+                                        .isInstallment(true)
+                                        .totalInstallments(3)
+                                        .build();
+
+                        when(bankAccountRepositoryPort.existsByIdAndProfileId(bankAccountId, profileId))
+                                        .thenReturn(true);
+
+                        DomainException exception = assertThrows(DomainException.class,
+                                        () -> transactionServiceAdapter.create(transaction));
+                        assertEquals("Parcelamento só é permitido para transações de cartão de crédito.",
+                                        exception.getMessage());
+                }
+
+                @Test
+                @DisplayName("Should throw exception when category is missing")
+                void shouldThrowExceptionWhenCategoryIsMissing() {
+                        UUID profileId = UUID.randomUUID();
+                        Transaction transaction = Transaction.builder()
+                                        .profileId(profileId)
+                                        .description("Test")
+                                        .amount(BigDecimal.valueOf(100))
+                                        .transactionDate(LocalDate.now())
+                                        .bankAccountId(UUID.randomUUID())
+                                        .build();
+
+                        assertThrows(DomainException.class, () -> transactionServiceAdapter.create(transaction));
+                }
+
+                @Test
+                @DisplayName("Should throw exception when credit card transaction has non-expense category")
+                void shouldThrowExceptionWhenCreditCardTransactionHasIncomeCategory() {
+                        UUID profileId = UUID.randomUUID();
+                        UUID creditCardId = UUID.randomUUID();
+                        UUID categoryId = UUID.randomUUID();
+                        Category category = createCategory(categoryId, profileId, CategoryType.INCOME);
+                        Transaction transaction = createCreditCardTransaction(profileId, creditCardId, categoryId);
+
+                        when(categoryRepositoryPort.findByIdAndProfileId(categoryId, profileId))
+                                        .thenReturn(Optional.of(category));
+
+                        assertThrows(DomainException.class, () -> transactionServiceAdapter.create(transaction));
+                }
         }
 
-        @Test
-        @DisplayName("Should create credit card transaction with automatic invoice creation")
-        void shouldCreateCreditCardTransactionWithInvoice() {
-            UUID profileId = UUID.randomUUID();
-            UUID creditCardId = UUID.randomUUID();
-            UUID invoiceId = UUID.randomUUID();
-            UUID categoryId = UUID.randomUUID();
-            Category category = createCategory(categoryId, profileId, CategoryType.EXPENSE);
-            Transaction transaction = createCreditCardTransaction(profileId, creditCardId, categoryId);
-            CreditCard creditCard = createCreditCard(creditCardId, profileId);
-            Invoice invoice = createInvoice(invoiceId, creditCardId);
+        @Nested
+        @DisplayName("Update Transaction Tests")
+        class UpdateTransactionTests {
 
-            when(categoryRepositoryPort.findByIdAndProfileId(categoryId, profileId)).thenReturn(Optional.of(category));
-            when(creditCardRepositoryPort.findByIdAndProfileId(creditCardId, profileId))
-                    .thenReturn(Optional.of(creditCard));
-            when(invoiceServicePort.getOrCreateInvoiceForDate(any(), any())).thenReturn(invoice);
-            when(transactionRepositoryPort.create(any())).thenAnswer(inv -> {
-                Transaction t = inv.getArgument(0);
-                t.setId(UUID.randomUUID());
-                return t;
-            });
+                @Test
+                @DisplayName("Should update transaction successfully")
+                void shouldUpdateTransactionSuccessfully() {
+                        UUID profileId = UUID.randomUUID();
+                        UUID transactionId = UUID.randomUUID();
+                        UUID bankAccountId = UUID.randomUUID();
+                        UUID categoryId = UUID.randomUUID();
+                        Category category = createCategory(categoryId, profileId, CategoryType.EXPENSE);
 
-            Transaction result = transactionServiceAdapter.create(transaction);
+                        Transaction existingTransaction = Transaction.builder()
+                                        .id(transactionId)
+                                        .profileId(profileId)
+                                        .description("Original")
+                                        .amount(BigDecimal.valueOf(100))
+                                        .transactionDate(LocalDate.now())
+                                        .bankAccountId(bankAccountId)
+                                        .categoryId(categoryId)
+                                        .type(TransactionType.EXPENSE)
+                                        .isInstallment(false)
+                                        .build();
 
-            assertNotNull(result);
-            assertEquals(invoiceId, result.getInvoiceId());
-            assertEquals(TransactionType.EXPENSE, result.getType());
-            verify(invoiceServicePort).updateInvoiceTotals(invoiceId);
+                        Transaction updatedTransaction = Transaction.builder()
+                                        .id(transactionId)
+                                        .profileId(profileId)
+                                        .description("Updated")
+                                        .amount(BigDecimal.valueOf(200))
+                                        .transactionDate(LocalDate.now())
+                                        .categoryId(categoryId)
+                                        .build();
+
+                        when(transactionRepositoryPort.findByIdAndProfileId(transactionId, profileId))
+                                        .thenReturn(Optional.of(existingTransaction));
+                        when(categoryRepositoryPort.findByIdAndProfileId(categoryId, profileId))
+                                        .thenReturn(Optional.of(category));
+                        when(categoryRepositoryPort.existsByIdAndProfileId(categoryId, profileId)).thenReturn(true);
+                        when(transactionRepositoryPort.update(any())).thenReturn(updatedTransaction);
+
+                        Transaction result = transactionServiceAdapter.update(updatedTransaction, profileId);
+
+                        assertNotNull(result);
+                        assertEquals("Updated", result.getDescription());
+                        verify(transactionRepositoryPort).update(any());
+                }
+
+                @Test
+                @DisplayName("Should throw exception when updating installment transaction")
+                void shouldThrowExceptionWhenUpdatingInstallmentTransaction() {
+                        UUID profileId = UUID.randomUUID();
+                        UUID transactionId = UUID.randomUUID();
+
+                        Transaction existingTransaction = Transaction.builder()
+                                        .id(transactionId)
+                                        .profileId(profileId)
+                                        .isInstallment(true)
+                                        .purchaseGroupUuid(UUID.randomUUID())
+                                        .build();
+
+                        Transaction updateRequest = Transaction.builder()
+                                        .id(transactionId)
+                                        .profileId(profileId)
+                                        .description("Updated")
+                                        .amount(BigDecimal.valueOf(200))
+                                        .build();
+
+                        when(transactionRepositoryPort.findByIdAndProfileId(transactionId, profileId))
+                                        .thenReturn(Optional.of(existingTransaction));
+
+                        assertThrows(DomainException.class,
+                                        () -> transactionServiceAdapter.update(updateRequest, profileId));
+                }
+
+                @Test
+                @DisplayName("Should throw exception when transaction not found for update")
+                void shouldThrowExceptionWhenTransactionNotFoundForUpdate() {
+                        UUID profileId = UUID.randomUUID();
+                        UUID transactionId = UUID.randomUUID();
+                        Transaction transaction = Transaction.builder()
+                                        .id(transactionId)
+                                        .profileId(profileId)
+                                        .description("Test")
+                                        .amount(BigDecimal.valueOf(100))
+                                        .build();
+
+                        when(transactionRepositoryPort.findByIdAndProfileId(transactionId, profileId))
+                                        .thenReturn(Optional.empty());
+
+                        assertThrows(ResourceNotFoundException.class,
+                                        () -> transactionServiceAdapter.update(transaction, profileId));
+                }
         }
 
-        @Test
-        @DisplayName("Should create installment transactions correctly")
-        void shouldCreateInstallmentTransactions() {
-            UUID profileId = UUID.randomUUID();
-            UUID creditCardId = UUID.randomUUID();
-            UUID categoryId = UUID.randomUUID();
-            Category category = createCategory(categoryId, profileId, CategoryType.EXPENSE);
-            Transaction transaction = createInstallmentTransaction(profileId, creditCardId, categoryId, 3);
-            CreditCard creditCard = createCreditCard(creditCardId, profileId);
+        @Nested
+        @DisplayName("Delete Transaction Tests")
+        class DeleteTransactionTests {
 
-            when(categoryRepositoryPort.findByIdAndProfileId(categoryId, profileId)).thenReturn(Optional.of(category));
-            when(creditCardRepositoryPort.findByIdAndProfileId(creditCardId, profileId))
-                    .thenReturn(Optional.of(creditCard));
-            when(invoiceServicePort.getOrCreateInvoiceForDate(any(), any()))
-                    .thenAnswer(inv -> createInvoice(UUID.randomUUID(), creditCardId));
-            when(transactionRepositoryPort.createAll(anyList())).thenAnswer(inv -> {
-                List<Transaction> transactions = inv.getArgument(0);
-                transactions.forEach(t -> t.setId(UUID.randomUUID()));
-                return transactions;
-            });
+                @Test
+                @DisplayName("Should delete single transaction successfully")
+                void shouldDeleteSingleTransactionSuccessfully() {
+                        UUID profileId = UUID.randomUUID();
+                        UUID transactionId = UUID.randomUUID();
+                        Transaction transaction = Transaction.builder()
+                                        .id(transactionId)
+                                        .profileId(profileId)
+                                        .isInstallment(false)
+                                        .build();
 
-            Transaction result = transactionServiceAdapter.create(transaction);
+                        when(transactionRepositoryPort.findByIdAndProfileId(transactionId, profileId))
+                                        .thenReturn(Optional.of(transaction));
 
-            assertNotNull(result);
-            assertTrue(result.getIsInstallment());
+                        transactionServiceAdapter.delete(transactionId, profileId);
 
-            ArgumentCaptor<List<Transaction>> captor = ArgumentCaptor.forClass(List.class);
-            verify(transactionRepositoryPort).createAll(captor.capture());
-            List<Transaction> installments = captor.getValue();
-            
-            assertEquals(3, installments.size());
-            assertEquals(1, installments.get(0).getInstallmentNumber());
-            assertEquals(2, installments.get(1).getInstallmentNumber());
-            assertEquals(3, installments.get(2).getInstallmentNumber());
+                        verify(transactionRepositoryPort).delete(transactionId);
+                }
+
+                @Test
+                @DisplayName("Should delete all installments when deleting installment transaction")
+                void shouldDeleteAllInstallmentsWhenDeletingInstallment() {
+                        UUID profileId = UUID.randomUUID();
+                        UUID transactionId = UUID.randomUUID();
+                        UUID purchaseGroupUuid = UUID.randomUUID();
+                        Transaction transaction = Transaction.builder()
+                                        .id(transactionId)
+                                        .profileId(profileId)
+                                        .isInstallment(true)
+                                        .purchaseGroupUuid(purchaseGroupUuid)
+                                        .build();
+
+                        when(transactionRepositoryPort.findByIdAndProfileId(transactionId, profileId))
+                                        .thenReturn(Optional.of(transaction));
+
+                        transactionServiceAdapter.delete(transactionId, profileId);
+
+                        verify(transactionRepositoryPort).deleteByPurchaseGroupUuid(purchaseGroupUuid);
+                        verify(transactionRepositoryPort, never()).delete(any());
+                }
+
+                @Test
+                @DisplayName("Should update invoice totals after deleting transaction with invoice")
+                void shouldUpdateInvoiceTotalsAfterDeletion() {
+                        UUID profileId = UUID.randomUUID();
+                        UUID transactionId = UUID.randomUUID();
+                        UUID invoiceId = UUID.randomUUID();
+                        Transaction transaction = Transaction.builder()
+                                        .id(transactionId)
+                                        .profileId(profileId)
+                                        .invoiceId(invoiceId)
+                                        .isInstallment(false)
+                                        .build();
+
+                        when(transactionRepositoryPort.findByIdAndProfileId(transactionId, profileId))
+                                        .thenReturn(Optional.of(transaction));
+
+                        transactionServiceAdapter.delete(transactionId, profileId);
+
+                        verify(invoiceServicePort).updateInvoiceTotals(invoiceId);
+                }
+
+                @Test
+                @DisplayName("Should throw exception when transaction not found for delete")
+                void shouldThrowExceptionWhenTransactionNotFoundForDelete() {
+                        UUID profileId = UUID.randomUUID();
+                        UUID transactionId = UUID.randomUUID();
+
+                        when(transactionRepositoryPort.findByIdAndProfileId(transactionId, profileId))
+                                        .thenReturn(Optional.empty());
+
+                        assertThrows(ResourceNotFoundException.class,
+                                        () -> transactionServiceAdapter.delete(transactionId, profileId));
+                }
         }
 
-        @Test
-        @DisplayName("Should throw exception when amount is zero or negative")
-        void shouldThrowExceptionWhenAmountIsInvalid() {
-            UUID profileId = UUID.randomUUID();
-            Transaction transaction = Transaction.builder()
-                    .profileId(profileId)
-                    .description("Test")
-                    .amount(BigDecimal.ZERO)
-                    .transactionDate(LocalDate.now())
-                    .bankAccountId(UUID.randomUUID())
-                    .categoryId(UUID.randomUUID())
-                    .build();
+        @Nested
+        @DisplayName("Find Transaction Tests")
+        class FindTransactionTests {
 
-            assertThrows(DomainException.class, () -> transactionServiceAdapter.create(transaction));
+                @Test
+                @DisplayName("Should find transaction by ID successfully")
+                void shouldFindTransactionByIdSuccessfully() {
+                        UUID profileId = UUID.randomUUID();
+                        UUID transactionId = UUID.randomUUID();
+                        Transaction transaction = Transaction.builder()
+                                        .id(transactionId)
+                                        .profileId(profileId)
+                                        .description("Test")
+                                        .build();
+
+                        when(transactionRepositoryPort.findByIdAndProfileId(transactionId, profileId))
+                                        .thenReturn(Optional.of(transaction));
+
+                        Transaction result = transactionServiceAdapter.findByIdAndProfileId(transactionId, profileId);
+
+                        assertNotNull(result);
+                        assertEquals(transactionId, result.getId());
+                }
+
+                @Test
+                @DisplayName("Should throw exception when transaction not found")
+                void shouldThrowExceptionWhenTransactionNotFound() {
+                        UUID profileId = UUID.randomUUID();
+                        UUID transactionId = UUID.randomUUID();
+
+                        when(transactionRepositoryPort.findByIdAndProfileId(transactionId, profileId))
+                                        .thenReturn(Optional.empty());
+
+                        assertThrows(ResourceNotFoundException.class,
+                                        () -> transactionServiceAdapter.findByIdAndProfileId(transactionId, profileId));
+                }
+
+                @Test
+                @DisplayName("Should find all transactions by profile ID")
+                void shouldFindAllTransactionsByProfileId() {
+                        UUID profileId = UUID.randomUUID();
+                        List<Transaction> transactions = List.of(
+                                        Transaction.builder().id(UUID.randomUUID()).description("Trans 1").build(),
+                                        Transaction.builder().id(UUID.randomUUID()).description("Trans 2").build());
+
+                        when(transactionRepositoryPort.findAllByProfileId(profileId)).thenReturn(transactions);
+
+                        List<Transaction> result = transactionServiceAdapter.findAllByProfileId(profileId);
+
+                        assertEquals(2, result.size());
+                }
         }
 
-        @Test
-        @DisplayName("Should throw exception when description is empty")
-        void shouldThrowExceptionWhenDescriptionIsEmpty() {
-            UUID profileId = UUID.randomUUID();
-            Transaction transaction = Transaction.builder()
-                    .profileId(profileId)
-                    .description("")
-                    .amount(BigDecimal.valueOf(100))
-                    .transactionDate(LocalDate.now())
-                    .bankAccountId(UUID.randomUUID())
-                    .categoryId(UUID.randomUUID())
-                    .build();
-
-            assertThrows(DomainException.class, () -> transactionServiceAdapter.create(transaction));
+        private Transaction createBankAccountTransaction(UUID profileId, UUID bankAccountId, UUID categoryId) {
+                return Transaction.builder()
+                                .profileId(profileId)
+                                .description("Test Transaction")
+                                .amount(BigDecimal.valueOf(100))
+                                .transactionDate(LocalDate.now())
+                                .bankAccountId(bankAccountId)
+                                .categoryId(categoryId)
+                                .build();
         }
 
-        @Test
-        @DisplayName("Should throw exception when neither bank account nor credit card is provided")
-        void shouldThrowExceptionWhenNoPaymentMethodProvided() {
-            UUID profileId = UUID.randomUUID();
-            Transaction transaction = Transaction.builder()
-                    .profileId(profileId)
-                    .description("Test")
-                    .amount(BigDecimal.valueOf(100))
-                    .transactionDate(LocalDate.now())
-                    .categoryId(UUID.randomUUID())
-                    .build();
-
-            assertThrows(DomainException.class, () -> transactionServiceAdapter.create(transaction));
+        private Transaction createCreditCardTransaction(UUID profileId, UUID creditCardId, UUID categoryId) {
+                return Transaction.builder()
+                                .profileId(profileId)
+                                .description("Test Credit Card Transaction")
+                                .amount(BigDecimal.valueOf(100))
+                                .transactionDate(LocalDate.now())
+                                .creditCardId(creditCardId)
+                                .categoryId(categoryId)
+                                .isInstallment(false)
+                                .build();
         }
 
-        @Test
-        @DisplayName("Should throw exception when both bank account and credit card are provided")
-        void shouldThrowExceptionWhenBothPaymentMethodsProvided() {
-            UUID profileId = UUID.randomUUID();
-            Transaction transaction = Transaction.builder()
-                    .profileId(profileId)
-                    .description("Test")
-                    .amount(BigDecimal.valueOf(100))
-                    .transactionDate(LocalDate.now())
-                    .bankAccountId(UUID.randomUUID())
-                    .creditCardId(UUID.randomUUID())
-                    .categoryId(UUID.randomUUID())
-                    .build();
-
-            assertThrows(DomainException.class, () -> transactionServiceAdapter.create(transaction));
+        private Transaction createInstallmentTransaction(UUID profileId, UUID creditCardId, UUID categoryId,
+                        int installments) {
+                return Transaction.builder()
+                                .profileId(profileId)
+                                .description("Installment Purchase")
+                                .amount(BigDecimal.valueOf(300))
+                                .transactionDate(LocalDate.now())
+                                .creditCardId(creditCardId)
+                                .categoryId(categoryId)
+                                .isInstallment(true)
+                                .totalInstallments(installments)
+                                .build();
         }
 
-        @Test
-        @DisplayName("Should throw exception when bank account not found")
-        void shouldThrowExceptionWhenBankAccountNotFound() {
-            UUID profileId = UUID.randomUUID();
-            UUID bankAccountId = UUID.randomUUID();
-            UUID categoryId = UUID.randomUUID();
-            Transaction transaction = createBankAccountTransaction(profileId, bankAccountId, categoryId);
-
-            when(bankAccountRepositoryPort.existsByIdAndProfileId(bankAccountId, profileId)).thenReturn(false);
-
-            assertThrows(ResourceNotFoundException.class, () -> transactionServiceAdapter.create(transaction));
+        private Category createCategory(UUID id, UUID profileId, CategoryType type) {
+                return Category.builder()
+                                .id(id)
+                                .profileId(profileId)
+                                .name("Test Category")
+                                .type(type)
+                                .build();
         }
 
-        @Test
-        @DisplayName("Should throw exception when credit card not found")
-        void shouldThrowExceptionWhenCreditCardNotFound() {
-            UUID profileId = UUID.randomUUID();
-            UUID creditCardId = UUID.randomUUID();
-            UUID categoryId = UUID.randomUUID();
-            Category category = createCategory(categoryId, profileId, CategoryType.EXPENSE);
-            Transaction transaction = createCreditCardTransaction(profileId, creditCardId, categoryId);
-
-            when(categoryRepositoryPort.findByIdAndProfileId(categoryId, profileId)).thenReturn(Optional.of(category));
-            when(creditCardRepositoryPort.findByIdAndProfileId(creditCardId, profileId))
-                    .thenReturn(Optional.empty());
-
-            assertThrows(ResourceNotFoundException.class, () -> transactionServiceAdapter.create(transaction));
+        private CreditCard createCreditCard(UUID id, UUID profileId) {
+                return CreditCard.builder()
+                                .id(id)
+                                .profileId(profileId)
+                                .name("Test Card")
+                                .closingDay(10)
+                                .dueDay(20)
+                                .creditLimit(BigDecimal.valueOf(5000))
+                                .build();
         }
 
-        @Test
-        @DisplayName("Should throw exception when installment count is less than 2")
-        void shouldThrowExceptionWhenInstallmentCountInvalid() {
-            UUID profileId = UUID.randomUUID();
-            Transaction transaction = Transaction.builder()
-                    .profileId(profileId)
-                    .description("Test")
-                    .amount(BigDecimal.valueOf(100))
-                    .transactionDate(LocalDate.now())
-                    .creditCardId(UUID.randomUUID())
-                    .categoryId(UUID.randomUUID())
-                    .isInstallment(true)
-                    .totalInstallments(1)
-                    .build();
-
-            assertThrows(DomainException.class, () -> transactionServiceAdapter.create(transaction));
+        private Invoice createInvoice(UUID id, UUID creditCardId) {
+                return Invoice.builder()
+                                .id(id)
+                                .creditCardId(creditCardId)
+                                .month(LocalDate.now().getMonthValue())
+                                .year(LocalDate.now().getYear())
+                                .closingDate(LocalDate.now().plusDays(10))
+                                .dueDate(LocalDate.now().plusDays(20))
+                                .totalAmount(BigDecimal.ZERO)
+                                .paidAmount(BigDecimal.ZERO)
+                                .status(InvoiceStatus.OPEN)
+                                .build();
         }
 
-        @Test
-        @DisplayName("Should throw exception when installment count exceeds 48")
-        void shouldThrowExceptionWhenInstallmentCountExceedsMax() {
-            UUID profileId = UUID.randomUUID();
-            Transaction transaction = Transaction.builder()
-                    .profileId(profileId)
-                    .description("Test")
-                    .amount(BigDecimal.valueOf(100))
-                    .transactionDate(LocalDate.now())
-                    .creditCardId(UUID.randomUUID())
-                    .categoryId(UUID.randomUUID())
-                    .isInstallment(true)
-                    .totalInstallments(49)
-                    .build();
+        @Nested
+        @DisplayName("Upload Receipt Tests")
+        class UploadReceiptTests {
 
-            assertThrows(DomainException.class, () -> transactionServiceAdapter.create(transaction));
+                @Test
+                @DisplayName("Should upload receipt successfully with valid file type")
+                void shouldUploadReceiptSuccessfully() {
+                        UUID profileId = UUID.randomUUID();
+                        UUID transactionId = UUID.randomUUID();
+                        Transaction transaction = Transaction.builder()
+                                        .id(transactionId)
+                                        .profileId(profileId)
+                                        .description("Test")
+                                        .build();
+
+                        when(transactionRepositoryPort.findByIdAndProfileId(transactionId, profileId))
+                                        .thenReturn(Optional.of(transaction));
+                        when(transactionRepositoryPort.update(any())).thenAnswer(inv -> inv.getArgument(0));
+
+                        java.io.InputStream content = new java.io.ByteArrayInputStream("fake image".getBytes());
+                        Transaction result = transactionServiceAdapter.uploadReceipt(
+                                        transactionId, profileId, content, "image/jpeg", 10L);
+
+                        assertNotNull(result);
+                        assertNotNull(result.getAttachmentKey());
+                        verify(storagePort).upload(anyString(), any(), eq("image/jpeg"), eq(10L), any());
+                }
+
+                @Test
+                @DisplayName("Should upload PDF successfully")
+                void shouldUploadPdfSuccessfully() {
+                        UUID profileId = UUID.randomUUID();
+                        UUID transactionId = UUID.randomUUID();
+                        Transaction transaction = Transaction.builder()
+                                        .id(transactionId)
+                                        .profileId(profileId)
+                                        .build();
+
+                        when(transactionRepositoryPort.findByIdAndProfileId(transactionId, profileId))
+                                        .thenReturn(Optional.of(transaction));
+                        when(transactionRepositoryPort.update(any())).thenAnswer(inv -> inv.getArgument(0));
+
+                        java.io.InputStream content = new java.io.ByteArrayInputStream("fake pdf".getBytes());
+                        Transaction result = transactionServiceAdapter.uploadReceipt(
+                                        transactionId, profileId, content, "application/pdf", 100L);
+
+                        assertNotNull(result.getAttachmentKey());
+                        verify(storagePort).upload(anyString(), any(), eq("application/pdf"), eq(100L), any());
+                }
+
+                @Test
+                @DisplayName("Should throw exception for invalid file type")
+                void shouldThrowExceptionForInvalidFileType() {
+                        UUID profileId = UUID.randomUUID();
+                        UUID transactionId = UUID.randomUUID();
+                        java.io.InputStream content = new java.io.ByteArrayInputStream("fake".getBytes());
+
+                        DomainException exception = assertThrows(DomainException.class,
+                                        () -> transactionServiceAdapter.uploadReceipt(
+                                                        transactionId, profileId, content, "text/plain", 10L));
+
+                        assertEquals("Tipo de arquivo não permitido. Tipos aceitos: JPG, JPEG, PNG, PDF.",
+                                        exception.getMessage());
+                        verify(storagePort, never()).upload(any(), any(), any(), anyLong(), any());
+                }
+
+                @Test
+                @DisplayName("Should throw exception when content type is null")
+                void shouldThrowExceptionWhenContentTypeIsNull() {
+                        UUID profileId = UUID.randomUUID();
+                        UUID transactionId = UUID.randomUUID();
+                        java.io.InputStream content = new java.io.ByteArrayInputStream("fake".getBytes());
+
+                        assertThrows(DomainException.class,
+                                        () -> transactionServiceAdapter.uploadReceipt(
+                                                        transactionId, profileId, content, null, 10L));
+
+                        verify(storagePort, never()).upload(any(), any(), any(), anyLong(), any());
+                }
+
+                @Test
+                @DisplayName("Should throw exception when transaction not found")
+                void shouldThrowExceptionWhenTransactionNotFound() {
+                        UUID profileId = UUID.randomUUID();
+                        UUID transactionId = UUID.randomUUID();
+                        java.io.InputStream content = new java.io.ByteArrayInputStream("fake".getBytes());
+
+                        when(transactionRepositoryPort.findByIdAndProfileId(transactionId, profileId))
+                                        .thenReturn(Optional.empty());
+
+                        assertThrows(ResourceNotFoundException.class,
+                                        () -> transactionServiceAdapter.uploadReceipt(
+                                                        transactionId, profileId, content, "image/png", 10L));
+                }
         }
-
-        @Test
-        @DisplayName("Should throw exception when trying to create installment with bank account")
-        void shouldThrowExceptionWhenInstallmentWithBankAccount() {
-            UUID profileId = UUID.randomUUID();
-            UUID bankAccountId = UUID.randomUUID();
-            Transaction transaction = Transaction.builder()
-                    .profileId(profileId)
-                    .description("Test")
-                    .amount(BigDecimal.valueOf(100))
-                    .transactionDate(LocalDate.now())
-                    .bankAccountId(bankAccountId)
-                    .categoryId(UUID.randomUUID())
-                    .isInstallment(true)
-                    .totalInstallments(3)
-                    .build();
-
-            when(bankAccountRepositoryPort.existsByIdAndProfileId(bankAccountId, profileId)).thenReturn(true);
-
-            DomainException exception = assertThrows(DomainException.class, 
-                    () -> transactionServiceAdapter.create(transaction));
-            assertEquals("Parcelamento só é permitido para transações de cartão de crédito.", 
-                    exception.getMessage());
-        }
-
-        @Test
-        @DisplayName("Should throw exception when category is missing")
-        void shouldThrowExceptionWhenCategoryIsMissing() {
-            UUID profileId = UUID.randomUUID();
-            Transaction transaction = Transaction.builder()
-                    .profileId(profileId)
-                    .description("Test")
-                    .amount(BigDecimal.valueOf(100))
-                    .transactionDate(LocalDate.now())
-                    .bankAccountId(UUID.randomUUID())
-                    .build();
-
-            assertThrows(DomainException.class, () -> transactionServiceAdapter.create(transaction));
-        }
-
-        @Test
-        @DisplayName("Should throw exception when credit card transaction has non-expense category")
-        void shouldThrowExceptionWhenCreditCardTransactionHasIncomeCategory() {
-            UUID profileId = UUID.randomUUID();
-            UUID creditCardId = UUID.randomUUID();
-            UUID categoryId = UUID.randomUUID();
-            Category category = createCategory(categoryId, profileId, CategoryType.INCOME);
-            Transaction transaction = createCreditCardTransaction(profileId, creditCardId, categoryId);
-
-            when(categoryRepositoryPort.findByIdAndProfileId(categoryId, profileId)).thenReturn(Optional.of(category));
-
-            assertThrows(DomainException.class, () -> transactionServiceAdapter.create(transaction));
-        }
-    }
-
-    @Nested
-    @DisplayName("Update Transaction Tests")
-    class UpdateTransactionTests {
-
-        @Test
-        @DisplayName("Should update transaction successfully")
-        void shouldUpdateTransactionSuccessfully() {
-            UUID profileId = UUID.randomUUID();
-            UUID transactionId = UUID.randomUUID();
-            UUID bankAccountId = UUID.randomUUID();
-            UUID categoryId = UUID.randomUUID();
-            Category category = createCategory(categoryId, profileId, CategoryType.EXPENSE);
-            
-            Transaction existingTransaction = Transaction.builder()
-                    .id(transactionId)
-                    .profileId(profileId)
-                    .description("Original")
-                    .amount(BigDecimal.valueOf(100))
-                    .transactionDate(LocalDate.now())
-                    .bankAccountId(bankAccountId)
-                    .categoryId(categoryId)
-                    .type(TransactionType.EXPENSE)
-                    .isInstallment(false)
-                    .build();
-
-            Transaction updatedTransaction = Transaction.builder()
-                    .id(transactionId)
-                    .profileId(profileId)
-                    .description("Updated")
-                    .amount(BigDecimal.valueOf(200))
-                    .transactionDate(LocalDate.now())
-                    .categoryId(categoryId)
-                    .build();
-
-            when(transactionRepositoryPort.findByIdAndProfileId(transactionId, profileId))
-                    .thenReturn(Optional.of(existingTransaction));
-            when(categoryRepositoryPort.findByIdAndProfileId(categoryId, profileId)).thenReturn(Optional.of(category));
-            when(categoryRepositoryPort.existsByIdAndProfileId(categoryId, profileId)).thenReturn(true);
-            when(transactionRepositoryPort.update(any())).thenReturn(updatedTransaction);
-
-            Transaction result = transactionServiceAdapter.update(updatedTransaction, profileId);
-
-            assertNotNull(result);
-            assertEquals("Updated", result.getDescription());
-            verify(transactionRepositoryPort).update(any());
-        }
-
-        @Test
-        @DisplayName("Should throw exception when updating installment transaction")
-        void shouldThrowExceptionWhenUpdatingInstallmentTransaction() {
-            UUID profileId = UUID.randomUUID();
-            UUID transactionId = UUID.randomUUID();
-            
-            Transaction existingTransaction = Transaction.builder()
-                    .id(transactionId)
-                    .profileId(profileId)
-                    .isInstallment(true)
-                    .purchaseGroupUuid(UUID.randomUUID())
-                    .build();
-
-            Transaction updateRequest = Transaction.builder()
-                    .id(transactionId)
-                    .profileId(profileId)
-                    .description("Updated")
-                    .amount(BigDecimal.valueOf(200))
-                    .build();
-
-            when(transactionRepositoryPort.findByIdAndProfileId(transactionId, profileId))
-                    .thenReturn(Optional.of(existingTransaction));
-
-            assertThrows(DomainException.class, 
-                    () -> transactionServiceAdapter.update(updateRequest, profileId));
-        }
-
-        @Test
-        @DisplayName("Should throw exception when transaction not found for update")
-        void shouldThrowExceptionWhenTransactionNotFoundForUpdate() {
-            UUID profileId = UUID.randomUUID();
-            UUID transactionId = UUID.randomUUID();
-            Transaction transaction = Transaction.builder()
-                    .id(transactionId)
-                    .profileId(profileId)
-                    .description("Test")
-                    .amount(BigDecimal.valueOf(100))
-                    .build();
-
-            when(transactionRepositoryPort.findByIdAndProfileId(transactionId, profileId))
-                    .thenReturn(Optional.empty());
-
-            assertThrows(ResourceNotFoundException.class, 
-                    () -> transactionServiceAdapter.update(transaction, profileId));
-        }
-    }
-
-    @Nested
-    @DisplayName("Delete Transaction Tests")
-    class DeleteTransactionTests {
-
-        @Test
-        @DisplayName("Should delete single transaction successfully")
-        void shouldDeleteSingleTransactionSuccessfully() {
-            UUID profileId = UUID.randomUUID();
-            UUID transactionId = UUID.randomUUID();
-            Transaction transaction = Transaction.builder()
-                    .id(transactionId)
-                    .profileId(profileId)
-                    .isInstallment(false)
-                    .build();
-
-            when(transactionRepositoryPort.findByIdAndProfileId(transactionId, profileId))
-                    .thenReturn(Optional.of(transaction));
-
-            transactionServiceAdapter.delete(transactionId, profileId);
-
-            verify(transactionRepositoryPort).delete(transactionId);
-        }
-
-        @Test
-        @DisplayName("Should delete all installments when deleting installment transaction")
-        void shouldDeleteAllInstallmentsWhenDeletingInstallment() {
-            UUID profileId = UUID.randomUUID();
-            UUID transactionId = UUID.randomUUID();
-            UUID purchaseGroupUuid = UUID.randomUUID();
-            Transaction transaction = Transaction.builder()
-                    .id(transactionId)
-                    .profileId(profileId)
-                    .isInstallment(true)
-                    .purchaseGroupUuid(purchaseGroupUuid)
-                    .build();
-
-            when(transactionRepositoryPort.findByIdAndProfileId(transactionId, profileId))
-                    .thenReturn(Optional.of(transaction));
-
-            transactionServiceAdapter.delete(transactionId, profileId);
-
-            verify(transactionRepositoryPort).deleteByPurchaseGroupUuid(purchaseGroupUuid);
-            verify(transactionRepositoryPort, never()).delete(any());
-        }
-
-        @Test
-        @DisplayName("Should update invoice totals after deleting transaction with invoice")
-        void shouldUpdateInvoiceTotalsAfterDeletion() {
-            UUID profileId = UUID.randomUUID();
-            UUID transactionId = UUID.randomUUID();
-            UUID invoiceId = UUID.randomUUID();
-            Transaction transaction = Transaction.builder()
-                    .id(transactionId)
-                    .profileId(profileId)
-                    .invoiceId(invoiceId)
-                    .isInstallment(false)
-                    .build();
-
-            when(transactionRepositoryPort.findByIdAndProfileId(transactionId, profileId))
-                    .thenReturn(Optional.of(transaction));
-
-            transactionServiceAdapter.delete(transactionId, profileId);
-
-            verify(invoiceServicePort).updateInvoiceTotals(invoiceId);
-        }
-
-        @Test
-        @DisplayName("Should throw exception when transaction not found for delete")
-        void shouldThrowExceptionWhenTransactionNotFoundForDelete() {
-            UUID profileId = UUID.randomUUID();
-            UUID transactionId = UUID.randomUUID();
-
-            when(transactionRepositoryPort.findByIdAndProfileId(transactionId, profileId))
-                    .thenReturn(Optional.empty());
-
-            assertThrows(ResourceNotFoundException.class, 
-                    () -> transactionServiceAdapter.delete(transactionId, profileId));
-        }
-    }
-
-    @Nested
-    @DisplayName("Find Transaction Tests")
-    class FindTransactionTests {
-
-        @Test
-        @DisplayName("Should find transaction by ID successfully")
-        void shouldFindTransactionByIdSuccessfully() {
-            UUID profileId = UUID.randomUUID();
-            UUID transactionId = UUID.randomUUID();
-            Transaction transaction = Transaction.builder()
-                    .id(transactionId)
-                    .profileId(profileId)
-                    .description("Test")
-                    .build();
-
-            when(transactionRepositoryPort.findByIdAndProfileId(transactionId, profileId))
-                    .thenReturn(Optional.of(transaction));
-
-            Transaction result = transactionServiceAdapter.findByIdAndProfileId(transactionId, profileId);
-
-            assertNotNull(result);
-            assertEquals(transactionId, result.getId());
-        }
-
-        @Test
-        @DisplayName("Should throw exception when transaction not found")
-        void shouldThrowExceptionWhenTransactionNotFound() {
-            UUID profileId = UUID.randomUUID();
-            UUID transactionId = UUID.randomUUID();
-
-            when(transactionRepositoryPort.findByIdAndProfileId(transactionId, profileId))
-                    .thenReturn(Optional.empty());
-
-            assertThrows(ResourceNotFoundException.class, 
-                    () -> transactionServiceAdapter.findByIdAndProfileId(transactionId, profileId));
-        }
-
-        @Test
-        @DisplayName("Should find all transactions by profile ID")
-        void shouldFindAllTransactionsByProfileId() {
-            UUID profileId = UUID.randomUUID();
-            List<Transaction> transactions = List.of(
-                    Transaction.builder().id(UUID.randomUUID()).description("Trans 1").build(),
-                    Transaction.builder().id(UUID.randomUUID()).description("Trans 2").build()
-            );
-
-            when(transactionRepositoryPort.findAllByProfileId(profileId)).thenReturn(transactions);
-
-            List<Transaction> result = transactionServiceAdapter.findAllByProfileId(profileId);
-
-            assertEquals(2, result.size());
-        }
-    }
-
-    private Transaction createBankAccountTransaction(UUID profileId, UUID bankAccountId, UUID categoryId) {
-        return Transaction.builder()
-                .profileId(profileId)
-                .description("Test Transaction")
-                .amount(BigDecimal.valueOf(100))
-                .transactionDate(LocalDate.now())
-                .bankAccountId(bankAccountId)
-                .categoryId(categoryId)
-                .build();
-    }
-
-    private Transaction createCreditCardTransaction(UUID profileId, UUID creditCardId, UUID categoryId) {
-        return Transaction.builder()
-                .profileId(profileId)
-                .description("Test Credit Card Transaction")
-                .amount(BigDecimal.valueOf(100))
-                .transactionDate(LocalDate.now())
-                .creditCardId(creditCardId)
-                .categoryId(categoryId)
-                .isInstallment(false)
-                .build();
-    }
-
-    private Transaction createInstallmentTransaction(UUID profileId, UUID creditCardId, UUID categoryId, int installments) {
-        return Transaction.builder()
-                .profileId(profileId)
-                .description("Installment Purchase")
-                .amount(BigDecimal.valueOf(300))
-                .transactionDate(LocalDate.now())
-                .creditCardId(creditCardId)
-                .categoryId(categoryId)
-                .isInstallment(true)
-                .totalInstallments(installments)
-                .build();
-    }
-
-    private Category createCategory(UUID id, UUID profileId, CategoryType type) {
-        return Category.builder()
-                .id(id)
-                .profileId(profileId)
-                .name("Test Category")
-                .type(type)
-                .build();
-    }
-
-    private CreditCard createCreditCard(UUID id, UUID profileId) {
-        return CreditCard.builder()
-                .id(id)
-                .profileId(profileId)
-                .name("Test Card")
-                .closingDay(10)
-                .dueDay(20)
-                .creditLimit(BigDecimal.valueOf(5000))
-                .build();
-    }
-
-    private Invoice createInvoice(UUID id, UUID creditCardId) {
-        return Invoice.builder()
-                .id(id)
-                .creditCardId(creditCardId)
-                .month(LocalDate.now().getMonthValue())
-                .year(LocalDate.now().getYear())
-                .closingDate(LocalDate.now().plusDays(10))
-                .dueDate(LocalDate.now().plusDays(20))
-                .totalAmount(BigDecimal.ZERO)
-                .paidAmount(BigDecimal.ZERO)
-                .status(InvoiceStatus.OPEN)
-                .build();
-    }
 }

--- a/poupeai-core-domain/src/main/java/io/github/poupeai/core/domain/port/business/TransactionServicePort.java
+++ b/poupeai-core-domain/src/main/java/io/github/poupeai/core/domain/port/business/TransactionServicePort.java
@@ -2,13 +2,20 @@ package io.github.poupeai.core.domain.port.business;
 
 import io.github.poupeai.core.domain.model.Transaction;
 
+import java.io.InputStream;
 import java.util.List;
 import java.util.UUID;
 
 public interface TransactionServicePort {
     Transaction create(Transaction transaction);
+
     Transaction update(Transaction transaction, UUID profileId);
+
     Transaction findByIdAndProfileId(UUID id, UUID profileId);
+
     List<Transaction> findAllByProfileId(UUID profileId);
+
     void delete(UUID id, UUID profileId);
+
+    Transaction uploadReceipt(UUID id, UUID profileId, InputStream content, String contentType, long size);
 }

--- a/poupeai-core-domain/src/main/java/io/github/poupeai/core/domain/port/business/TransactionServicePort.java
+++ b/poupeai-core-domain/src/main/java/io/github/poupeai/core/domain/port/business/TransactionServicePort.java
@@ -18,4 +18,6 @@ public interface TransactionServicePort {
     void delete(UUID id, UUID profileId);
 
     Transaction uploadReceipt(UUID id, UUID profileId, InputStream content, String contentType, long size);
+
+    Transaction deleteReceipt(UUID id, UUID profileId);
 }

--- a/poupeai-core-domain/src/main/java/io/github/poupeai/core/domain/port/output/StoragePort.java
+++ b/poupeai-core-domain/src/main/java/io/github/poupeai/core/domain/port/output/StoragePort.java
@@ -5,4 +5,6 @@ import java.util.Map;
 
 public interface StoragePort {
     void upload(String key, InputStream content, String contentType, long size, Map<String, String> tags);
+
+    void delete(String key);
 }

--- a/poupeai-core-domain/src/main/java/io/github/poupeai/core/domain/port/output/StoragePort.java
+++ b/poupeai-core-domain/src/main/java/io/github/poupeai/core/domain/port/output/StoragePort.java
@@ -1,0 +1,8 @@
+package io.github.poupeai.core.domain.port.output;
+
+import java.io.InputStream;
+import java.util.Map;
+
+public interface StoragePort {
+    void upload(String key, InputStream content, String contentType, long size, Map<String, String> tags);
+}

--- a/poupeai-core-persistence/pom.xml
+++ b/poupeai-core-persistence/pom.xml
@@ -42,6 +42,19 @@
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>io.minio</groupId>
+            <artifactId>minio</artifactId>
+            <version>8.6.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp-urlconnection</artifactId>
+            <version>5.3.2</version>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/adapter/MinioStorageAdapter.java
+++ b/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/adapter/MinioStorageAdapter.java
@@ -1,0 +1,74 @@
+package io.github.poupeai.core.persistence.adapter;
+
+import io.github.poupeai.core.domain.port.output.StoragePort;
+import io.minio.BucketExistsArgs;
+import io.minio.MakeBucketArgs;
+import io.minio.MinioClient;
+import io.minio.PutObjectArgs;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.InputStream;
+import java.util.Map;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class MinioStorageAdapter implements StoragePort {
+
+    @Value("${minio.bucket-name:poupeai-receipts}")
+    private String bucketName;
+
+    @Value("${minio.endpoint:http://localhost:9000}")
+    private String endpoint;
+
+    @Value("${minio.access-key:minioadmin}")
+    private String accessKey;
+
+    @Value("${minio.secret-key:minioadmin}")
+    private String secretKey;
+
+    private MinioClient minioClient;
+
+    private MinioClient getClient() {
+        if (minioClient == null) {
+            minioClient = MinioClient.builder()
+                    .endpoint(endpoint)
+                    .credentials(accessKey, secretKey)
+                    .build();
+        }
+        return minioClient;
+    }
+
+    @Override
+    public void upload(String key, InputStream content, String contentType, long size, Map<String, String> tags) {
+        try {
+            MinioClient client = getClient();
+            boolean found = client.bucketExists(BucketExistsArgs.builder().bucket(bucketName).build());
+            if (!found) {
+                client.makeBucket(MakeBucketArgs.builder().bucket(bucketName).build());
+                log.info("Bucket '{}' criado.", bucketName);
+            }
+
+            var builder = PutObjectArgs.builder()
+                    .bucket(bucketName)
+                    .object(key)
+                    .stream(content, size, -1)
+                    .contentType(contentType);
+
+            if (tags != null && !tags.isEmpty()) {
+                builder.tags(tags);
+            }
+
+            client.putObject(builder.build());
+
+            log.info("Arquivo enviado com sucesso: bucket='{}', key='{}', tags={}", bucketName, key, tags);
+
+        } catch (Exception e) {
+            log.error("Erro ao enviar arquivo para o MinIO", e);
+            throw new RuntimeException("Falha ao enviar arquivo para o storage", e);
+        }
+    }
+}

--- a/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/adapter/MinioStorageAdapter.java
+++ b/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/adapter/MinioStorageAdapter.java
@@ -5,6 +5,7 @@ import io.minio.BucketExistsArgs;
 import io.minio.MakeBucketArgs;
 import io.minio.MinioClient;
 import io.minio.PutObjectArgs;
+import io.minio.RemoveObjectArgs;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -69,6 +70,22 @@ public class MinioStorageAdapter implements StoragePort {
         } catch (Exception e) {
             log.error("Erro ao enviar arquivo para o MinIO", e);
             throw new RuntimeException("Falha ao enviar arquivo para o storage", e);
+        }
+    }
+
+    @Override
+    public void delete(String key) {
+        try {
+            MinioClient client = getClient();
+            client.removeObject(
+                    RemoveObjectArgs.builder()
+                            .bucket(bucketName)
+                            .object(key)
+                            .build());
+            log.info("Arquivo removido com sucesso: bucket='{}', key='{}'", bucketName, key);
+        } catch (Exception e) {
+            log.error("Erro ao remover arquivo do MinIO: key='{}'", key, e);
+            throw new RuntimeException("Falha ao remover arquivo do storage", e);
         }
     }
 }

--- a/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/adapter/MinioStorageAdapter.java
+++ b/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/adapter/MinioStorageAdapter.java
@@ -6,7 +6,7 @@ import io.minio.MakeBucketArgs;
 import io.minio.MinioClient;
 import io.minio.PutObjectArgs;
 import io.minio.RemoveObjectArgs;
-import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -16,7 +16,6 @@ import java.util.Map;
 
 @Component
 @Slf4j
-@RequiredArgsConstructor
 public class MinioStorageAdapter implements StoragePort {
 
     @Value("${minio.bucket-name:poupeai-receipts}")
@@ -31,9 +30,10 @@ public class MinioStorageAdapter implements StoragePort {
     @Value("${minio.secret-key:minioadmin}")
     private String secretKey;
 
+    @Setter
     private MinioClient minioClient;
 
-    private MinioClient getClient() {
+    MinioClient getClient() {
         if (minioClient == null) {
             minioClient = MinioClient.builder()
                     .endpoint(endpoint)
@@ -41,6 +41,14 @@ public class MinioStorageAdapter implements StoragePort {
                     .build();
         }
         return minioClient;
+    }
+
+    String getBucketName() {
+        return bucketName;
+    }
+
+    void setBucketName(String bucketName) {
+        this.bucketName = bucketName;
     }
 
     @Override

--- a/poupeai-core-persistence/src/test/java/io/github/poupeai/core/persistence/adapter/MinioStorageAdapterTest.java
+++ b/poupeai-core-persistence/src/test/java/io/github/poupeai/core/persistence/adapter/MinioStorageAdapterTest.java
@@ -1,0 +1,179 @@
+package io.github.poupeai.core.persistence.adapter;
+
+import io.minio.BucketExistsArgs;
+import io.minio.MakeBucketArgs;
+import io.minio.MinioClient;
+import io.minio.ObjectWriteResponse;
+import io.minio.PutObjectArgs;
+import io.minio.RemoveObjectArgs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MinioStorageAdapter Tests")
+class MinioStorageAdapterTest {
+
+    @Mock
+    private MinioClient minioClient;
+
+    private MinioStorageAdapter minioStorageAdapter;
+
+    @BeforeEach
+    void setUp() {
+        minioStorageAdapter = new MinioStorageAdapter();
+        minioStorageAdapter.setMinioClient(minioClient);
+        minioStorageAdapter.setBucketName("test-bucket");
+    }
+
+    @Nested
+    @DisplayName("Upload Tests")
+    class UploadTests {
+
+        @Test
+        @DisplayName("Should upload file successfully when bucket exists")
+        void shouldUploadFileSuccessfullyWhenBucketExists() throws Exception {
+            when(minioClient.bucketExists(any(BucketExistsArgs.class))).thenReturn(true);
+            when(minioClient.putObject(any(PutObjectArgs.class))).thenReturn(mock(ObjectWriteResponse.class));
+
+            InputStream content = new ByteArrayInputStream("test content".getBytes());
+            Map<String, String> tags = Map.of("key1", "value1");
+
+            assertDoesNotThrow(() -> minioStorageAdapter.upload("test-key", content, "image/jpeg", 12L, tags));
+
+            verify(minioClient).bucketExists(any(BucketExistsArgs.class));
+            verify(minioClient, never()).makeBucket(any(MakeBucketArgs.class));
+            verify(minioClient).putObject(any(PutObjectArgs.class));
+        }
+
+        @Test
+        @DisplayName("Should create bucket when it does not exist")
+        void shouldCreateBucketWhenNotExists() throws Exception {
+            when(minioClient.bucketExists(any(BucketExistsArgs.class))).thenReturn(false);
+            when(minioClient.putObject(any(PutObjectArgs.class))).thenReturn(mock(ObjectWriteResponse.class));
+
+            InputStream content = new ByteArrayInputStream("test content".getBytes());
+
+            minioStorageAdapter.upload("test-key", content, "image/png", 12L, null);
+
+            verify(minioClient).makeBucket(any(MakeBucketArgs.class));
+            verify(minioClient).putObject(any(PutObjectArgs.class));
+        }
+
+        @Test
+        @DisplayName("Should upload without tags when tags are null")
+        void shouldUploadWithoutTagsWhenNull() throws Exception {
+            when(minioClient.bucketExists(any(BucketExistsArgs.class))).thenReturn(true);
+            when(minioClient.putObject(any(PutObjectArgs.class))).thenReturn(mock(ObjectWriteResponse.class));
+
+            InputStream content = new ByteArrayInputStream("test".getBytes());
+
+            assertDoesNotThrow(() -> minioStorageAdapter.upload("key", content, "application/pdf", 4L, null));
+
+            verify(minioClient).putObject(any(PutObjectArgs.class));
+        }
+
+        @Test
+        @DisplayName("Should upload without tags when tags are empty")
+        void shouldUploadWithoutTagsWhenEmpty() throws Exception {
+            when(minioClient.bucketExists(any(BucketExistsArgs.class))).thenReturn(true);
+            when(minioClient.putObject(any(PutObjectArgs.class))).thenReturn(mock(ObjectWriteResponse.class));
+
+            InputStream content = new ByteArrayInputStream("test".getBytes());
+
+            assertDoesNotThrow(() -> minioStorageAdapter.upload("key", content, "application/pdf", 4L, Map.of()));
+
+            verify(minioClient).putObject(any(PutObjectArgs.class));
+        }
+
+        @Test
+        @DisplayName("Should throw RuntimeException when upload fails")
+        void shouldThrowRuntimeExceptionWhenUploadFails() throws Exception {
+            when(minioClient.bucketExists(any(BucketExistsArgs.class))).thenReturn(true);
+            when(minioClient.putObject(any(PutObjectArgs.class))).thenThrow(new RuntimeException("Connection failed"));
+
+            InputStream content = new ByteArrayInputStream("test".getBytes());
+
+            RuntimeException exception = assertThrows(RuntimeException.class,
+                    () -> minioStorageAdapter.upload("key", content, "image/jpeg", 4L, null));
+
+            assertEquals("Falha ao enviar arquivo para o storage", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should throw RuntimeException when bucket check fails")
+        void shouldThrowRuntimeExceptionWhenBucketCheckFails() throws Exception {
+            when(minioClient.bucketExists(any(BucketExistsArgs.class)))
+                    .thenThrow(new RuntimeException("Network error"));
+
+            InputStream content = new ByteArrayInputStream("test".getBytes());
+
+            RuntimeException exception = assertThrows(RuntimeException.class,
+                    () -> minioStorageAdapter.upload("key", content, "image/jpeg", 4L, null));
+
+            assertEquals("Falha ao enviar arquivo para o storage", exception.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("Delete Tests")
+    class DeleteTests {
+
+        @Test
+        @DisplayName("Should delete file successfully")
+        void shouldDeleteFileSuccessfully() throws Exception {
+            doNothing().when(minioClient).removeObject(any(RemoveObjectArgs.class));
+
+            assertDoesNotThrow(() -> minioStorageAdapter.delete("test-key"));
+
+            ArgumentCaptor<RemoveObjectArgs> captor = ArgumentCaptor.forClass(RemoveObjectArgs.class);
+            verify(minioClient).removeObject(captor.capture());
+
+            RemoveObjectArgs args = captor.getValue();
+            assertEquals("test-bucket", args.bucket());
+            assertEquals("test-key", args.object());
+        }
+
+        @Test
+        @DisplayName("Should throw RuntimeException when delete fails")
+        void shouldThrowRuntimeExceptionWhenDeleteFails() throws Exception {
+            doThrow(new RuntimeException("Delete failed")).when(minioClient).removeObject(any(RemoveObjectArgs.class));
+
+            RuntimeException exception = assertThrows(RuntimeException.class,
+                    () -> minioStorageAdapter.delete("test-key"));
+
+            assertEquals("Falha ao remover arquivo do storage", exception.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("Client Initialization Tests")
+    class ClientInitializationTests {
+
+        @Test
+        @DisplayName("Should return injected client")
+        void shouldReturnInjectedClient() {
+            MinioClient client = minioStorageAdapter.getClient();
+            assertSame(minioClient, client);
+        }
+
+        @Test
+        @DisplayName("Should return bucket name")
+        void shouldReturnBucketName() {
+            assertEquals("test-bucket", minioStorageAdapter.getBucketName());
+        }
+    }
+}

--- a/poupeai-core-web/src/main/java/io/github/poupeai/core/web/controller/transaction/TransactionController.java
+++ b/poupeai-core-web/src/main/java/io/github/poupeai/core/web/controller/transaction/TransactionController.java
@@ -112,4 +112,16 @@ public class TransactionController {
 
         return ResponseEntity.ok(transactionMapper.toResponse(transaction));
     }
+
+    @DeleteMapping("/{id}/receipt")
+    @Operation(summary = "Remover comprovante", description = "Remove o comprovante de uma transação.", security = @SecurityRequirement(name = "bearer-key"))
+    public ResponseEntity<TransactionResponse> deleteReceipt(
+            @Parameter(hidden = true) @CurrentUserId String userId,
+            @PathVariable UUID id) {
+
+        UUID profileId = UUID.fromString(userId);
+        Transaction transaction = transactionServicePort.deleteReceipt(id, profileId);
+
+        return ResponseEntity.ok(transactionMapper.toResponse(transaction));
+    }
 }

--- a/poupeai-core-web/src/main/java/io/github/poupeai/core/web/controller/transaction/TransactionController.java
+++ b/poupeai-core-web/src/main/java/io/github/poupeai/core/web/controller/transaction/TransactionController.java
@@ -35,13 +35,9 @@ public class TransactionController {
     private final TransactionControllerMapper transactionMapper;
 
     @GetMapping
-    @Operation(
-        summary = "Listar transações",
-        description = "Retorna todas as transações do usuário",
-        security = @SecurityRequirement(name = "bearer-key")
-    )
+    @Operation(summary = "Listar transações", description = "Retorna todas as transações do usuário", security = @SecurityRequirement(name = "bearer-key"))
     public ResponseEntity<List<TransactionResponse>> getTransactions(
-        @Parameter(hidden = true) @CurrentUserId String userId) {
+            @Parameter(hidden = true) @CurrentUserId String userId) {
 
         UUID profileId = UUID.fromString(userId);
         List<Transaction> transactions = transactionServicePort.findAllByProfileId(profileId);
@@ -49,14 +45,10 @@ public class TransactionController {
     }
 
     @GetMapping("/{id}")
-    @Operation(
-        summary = "Obter transação por ID",
-        description = "Retorna detalhes de uma transação específica",
-        security = @SecurityRequirement(name = "bearer-key")
-    )
+    @Operation(summary = "Obter transação por ID", description = "Retorna detalhes de uma transação específica", security = @SecurityRequirement(name = "bearer-key"))
     public ResponseEntity<TransactionResponse> getTransactionById(
-        @Parameter(hidden = true) @CurrentUserId String userId,
-        @PathVariable UUID id) {
+            @Parameter(hidden = true) @CurrentUserId String userId,
+            @PathVariable UUID id) {
 
         UUID profileId = UUID.fromString(userId);
         Transaction transaction = transactionServicePort.findByIdAndProfileId(id, profileId);
@@ -64,14 +56,10 @@ public class TransactionController {
     }
 
     @PostMapping
-    @Operation(
-        summary = "Criar transação",
-        description = "Cria uma nova transação. Transações parceladas geram múltiplas transações automaticamente.",
-        security = @SecurityRequirement(name = "bearer-key")
-    )
+    @Operation(summary = "Criar transação", description = "Cria uma nova transação. Transações parceladas geram múltiplas transações automaticamente.", security = @SecurityRequirement(name = "bearer-key"))
     public ResponseEntity<TransactionResponse> createTransaction(
-        @Parameter(hidden = true) @CurrentUserId String userId,
-        @RequestBody @Valid TransactionRequest request) {
+            @Parameter(hidden = true) @CurrentUserId String userId,
+            @RequestBody @Valid TransactionRequest request) {
 
         UUID profileId = UUID.fromString(userId);
         Transaction transaction = transactionMapper.toDomain(request, profileId);
@@ -81,15 +69,11 @@ public class TransactionController {
     }
 
     @PatchMapping("/{id}")
-    @Operation(
-        summary = "Atualizar transação",
-        description = "Atualiza os dados de uma transação existente.",
-        security = @SecurityRequirement(name = "bearer-key")
-    )
+    @Operation(summary = "Atualizar transação", description = "Atualiza os dados de uma transação existente.", security = @SecurityRequirement(name = "bearer-key"))
     public ResponseEntity<TransactionResponse> updateTransaction(
-        @Parameter(hidden = true) @CurrentUserId String userId,
-        @PathVariable UUID id,
-        @RequestBody @Valid TransactionUpdateRequest request) {
+            @Parameter(hidden = true) @CurrentUserId String userId,
+            @PathVariable UUID id,
+            @RequestBody @Valid TransactionUpdateRequest request) {
 
         UUID profileId = UUID.fromString(userId);
         Transaction transaction = transactionServicePort.findByIdAndProfileId(id, profileId);
@@ -100,17 +84,32 @@ public class TransactionController {
     }
 
     @DeleteMapping("/{id}")
-    @Operation(
-        summary = "Deletar transação",
-        description = "Deleta uma transação específica. Se a transação for parcelada, todas as parcelas serão deletadas.",
-        security = @SecurityRequirement(name = "bearer-key")
-    )
+    @Operation(summary = "Deletar transação", description = "Deleta uma transação específica. Se a transação for parcelada, todas as parcelas serão deletadas.", security = @SecurityRequirement(name = "bearer-key"))
     public ResponseEntity<Void> deleteTransaction(
-        @Parameter(hidden = true) @CurrentUserId String userId,
-        @PathVariable UUID id) {
+            @Parameter(hidden = true) @CurrentUserId String userId,
+            @PathVariable UUID id) {
 
         UUID profileId = UUID.fromString(userId);
         transactionServicePort.delete(id, profileId);
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping(value = "/{id}/receipt", consumes = org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "Upload de comprovante", description = "Realiza o upload do comprovante para uma transação.", security = @SecurityRequirement(name = "bearer-key"))
+    public ResponseEntity<TransactionResponse> uploadReceipt(
+            @Parameter(hidden = true) @CurrentUserId String userId,
+            @PathVariable UUID id,
+            @org.springframework.web.bind.annotation.RequestParam("file") org.springframework.web.multipart.MultipartFile file)
+            throws java.io.IOException {
+
+        UUID profileId = UUID.fromString(userId);
+        Transaction transaction = transactionServicePort.uploadReceipt(
+                id,
+                profileId,
+                file.getInputStream(),
+                file.getContentType(),
+                file.getSize());
+
+        return ResponseEntity.ok(transactionMapper.toResponse(transaction));
     }
 }


### PR DESCRIPTION
## Implementação do upload/remoção de comprovantes

Implementada a funcionalidade de upload de comprovantes.
Tipos permitidos: JPG, JPEG, PNG e PDF.
Tamanho máximo: 5MB.
Cada arquivo recebe duas tags no MinIO para facilitar a categorização dos comprovantes: profileId e transactionId.
Quando uma transação que possui comprovante recebe outro, o comprovante antigo é excluído do MinIO.
O endpoint para deletar comprovantes remove o arquivo do MinIO.

### Testes
<img width="971" height="98" alt="image" src="https://github.com/user-attachments/assets/0b5d8766-ecd0-4191-8a2d-bb02c2664b2d" />
<img width="867" height="41" alt="image" src="https://github.com/user-attachments/assets/4d610f16-acb5-414c-b9e3-e1b3c2da105a" />
<img width="1265" height="46" alt="image" src="https://github.com/user-attachments/assets/4d44804e-a76a-4529-a17d-e153ad2c5ed6" />
<img width="1917" height="938" alt="image" src="https://github.com/user-attachments/assets/edbf9c95-cca4-4174-8d88-87a03c7af25e" />
<img width="815" height="886" alt="image" src="https://github.com/user-attachments/assets/fa36076d-efe8-495d-9d42-4fb42e299c9d" />
<img width="1915" height="939" alt="image" src="https://github.com/user-attachments/assets/abc23992-e644-4309-a590-427c9c468c1a" />


Resolves #21 #24 #49 