### PR TITLE
51 backendcore service 160 adicionar campos de informações para a interface no endpoint de metas

### DIFF
--- a/poupeai-core-domain/src/main/java/io/github/poupeai/core/domain/model/Goal.java
+++ b/poupeai-core-domain/src/main/java/io/github/poupeai/core/domain/model/Goal.java
@@ -18,7 +18,11 @@ public class Goal {
     private UUID id;
     private UUID profileId;
     private String name;
+    private String description;
+    private String colorHex;
+    private BigDecimal initialBalance;
     private BigDecimal goalAmount;
+    private BigDecimal currentBalance;
     private LocalDate targetDate;
     private LocalDate completedAt;
     private OffsetDateTime createdAt;

--- a/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/adapter/GoalRepositoryAdapter.java
+++ b/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/adapter/GoalRepositoryAdapter.java
@@ -46,6 +46,9 @@ public class GoalRepositoryAdapter implements GoalRepositoryPort {
         var profile = profileRepository.getReferenceById(goal.getProfileId());
         existingGoal.setProfile(profile);
         existingGoal.setName(goal.getName());
+        existingGoal.setDescription(goal.getDescription());
+        existingGoal.setColorHex(goal.getColorHex());
+        existingGoal.setInitialBalance(goal.getInitialBalance());
         existingGoal.setGoalAmount(goal.getGoalAmount());
         existingGoal.setTargetDate(goal.getTargetDate());
         existingGoal.setCompletedAt(goal.getCompletedAt());

--- a/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/adapter/GoalRepositoryAdapter.java
+++ b/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/adapter/GoalRepositoryAdapter.java
@@ -4,11 +4,13 @@ import io.github.poupeai.core.domain.exception.ResourceNotFoundException;
 import io.github.poupeai.core.domain.model.Goal;
 import io.github.poupeai.core.domain.port.persistence.GoalRepositoryPort;
 import io.github.poupeai.core.persistence.mapper.GoalEntityMapper;
+import io.github.poupeai.core.persistence.repository.GoalDepositRepository;
 import io.github.poupeai.core.persistence.repository.GoalRepository;
 import io.github.poupeai.core.persistence.repository.ProfileRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -20,6 +22,7 @@ public class GoalRepositoryAdapter implements GoalRepositoryPort {
     private final GoalRepository goalRepository;
     private final GoalEntityMapper goalMapper;
     private final ProfileRepository profileRepository;
+    private final GoalDepositRepository goalDepositRepository;
 
     @Override
     public Goal create(Goal goal) {
@@ -29,7 +32,10 @@ public class GoalRepositoryAdapter implements GoalRepositoryPort {
         entity.setProfile(profile);
         
         var savedEntity = goalRepository.save(entity);
-        return goalMapper.toDomain(savedEntity);
+        Goal domain = goalMapper.toDomain(savedEntity);
+        domain.setInitialBalance(domain.getInitialBalance() == null ? BigDecimal.ZERO : domain.getInitialBalance());
+        domain.setCurrentBalance(calculateCurrentBalance(domain.getId(), domain.getInitialBalance()));
+        return domain;
     }
 
     @Override
@@ -45,18 +51,31 @@ public class GoalRepositoryAdapter implements GoalRepositoryPort {
         existingGoal.setCompletedAt(goal.getCompletedAt());
 
         var savedEntity = goalRepository.save(existingGoal);
-        return goalMapper.toDomain(savedEntity);
+        Goal domain = goalMapper.toDomain(savedEntity);
+        domain.setInitialBalance(domain.getInitialBalance() == null ? BigDecimal.ZERO : domain.getInitialBalance());
+        domain.setCurrentBalance(calculateCurrentBalance(domain.getId(), domain.getInitialBalance()));
+        return domain;
     }
 
     @Override
     public Optional<Goal> findByIdAndProfileId(UUID id, UUID profileId) {
-        return goalRepository.findByIdAndProfile_UserId(id, profileId).map(goalMapper::toDomain);
+        return goalRepository.findByIdAndProfile_UserId(id, profileId).map(entity -> {
+            Goal domain = goalMapper.toDomain(entity);
+            domain.setInitialBalance(domain.getInitialBalance() == null ? BigDecimal.ZERO : domain.getInitialBalance());
+            domain.setCurrentBalance(calculateCurrentBalance(domain.getId(), domain.getInitialBalance()));
+            return domain;
+        });
     }
 
     @Override
     public List<Goal> findAllByProfileId(UUID profileId) {
         var entities = goalRepository.findAllByProfile_UserId(profileId);
-        return goalMapper.toDomainList(entities);
+        var domains = goalMapper.toDomainList(entities);
+        for (Goal domain : domains) {
+            domain.setInitialBalance(domain.getInitialBalance() == null ? BigDecimal.ZERO : domain.getInitialBalance());
+            domain.setCurrentBalance(calculateCurrentBalance(domain.getId(), domain.getInitialBalance()));
+        }
+        return domains;
     }
 
     @Override
@@ -67,5 +86,13 @@ public class GoalRepositoryAdapter implements GoalRepositoryPort {
     @Override
     public boolean existsByIdAndProfileId(UUID id, UUID profileId) {
         return goalRepository.existsByIdAndProfile_UserId(id, profileId);
+    }
+
+    private BigDecimal calculateCurrentBalance(UUID goalId, BigDecimal initialBalance) {
+        var deposits = goalDepositRepository.findAllByGoal_Id(goalId);
+        BigDecimal sum = deposits.stream()
+            .map(e -> e.getDepositAmount() == null ? BigDecimal.ZERO : e.getDepositAmount())
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
+        return (initialBalance == null ? BigDecimal.ZERO : initialBalance).add(sum);
     }
 }

--- a/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/adapter/GoalRepositoryAdapter.java
+++ b/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/adapter/GoalRepositoryAdapter.java
@@ -93,6 +93,9 @@ public class GoalRepositoryAdapter implements GoalRepositoryPort {
 
     private BigDecimal calculateCurrentBalance(UUID goalId, BigDecimal initialBalance) {
         var deposits = goalDepositRepository.findAllByGoal_Id(goalId);
+        if (deposits == null || deposits.isEmpty()) {
+            return (initialBalance == null ? BigDecimal.ZERO : initialBalance);
+        }
         BigDecimal sum = deposits.stream()
             .map(e -> e.getDepositAmount() == null ? BigDecimal.ZERO : e.getDepositAmount())
             .reduce(BigDecimal.ZERO, BigDecimal::add);

--- a/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/config/MapperConfig.java
+++ b/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/config/MapperConfig.java
@@ -1,0 +1,15 @@
+package io.github.poupeai.core.persistence.config;
+
+import io.github.poupeai.core.persistence.mapper.BankAccountEntityMapper;
+import org.mapstruct.factory.Mappers;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MapperConfig {
+
+    // Mapper bean registration removed to avoid duplicate bean with MapStruct-generated component.
+    // MapStruct generates a Spring @Component for mappers when componentModel = "spring",
+    // so manual registration is not necessary.
+
+}

--- a/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/entity/GoalEntity.java
+++ b/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/entity/GoalEntity.java
@@ -51,6 +51,15 @@ public class GoalEntity {
     @Column(name = "completed_at")
     private LocalDate completedAt;
 
+    @Column(name = "description")
+    private String description;
+
+    @Column(name = "color_hex")
+    private String colorHex;
+
+    @Column(name = "initial_balance", precision = 15, scale = 2)
+    private java.math.BigDecimal initialBalance;
+
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     private OffsetDateTime createdAt;

--- a/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/mapper/GoalEntityMapper.java
+++ b/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/mapper/GoalEntityMapper.java
@@ -10,12 +10,14 @@ import java.util.List;
 @Mapper(componentModel = "spring")
 public interface GoalEntityMapper {
     @Mapping(target = "profileId", source = "profile.userId")
+    @Mapping(target = "description", ignore = true)
+    @Mapping(target = "colorHex", ignore = true)
+    @Mapping(target = "initialBalance", ignore = true)
+    @Mapping(target = "currentBalance", ignore = true)
     Goal toDomain(GoalEntity entity);
 
     @Mapping(target = "profile", ignore = true)
     GoalEntity toEntity(Goal domain);
 
     List<Goal> toDomainList(List<GoalEntity> entities);
-
-    List<GoalEntity> toEntityList(List<Goal> domains);
 }

--- a/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/mapper/GoalEntityMapper.java
+++ b/poupeai-core-persistence/src/main/java/io/github/poupeai/core/persistence/mapper/GoalEntityMapper.java
@@ -10,13 +10,16 @@ import java.util.List;
 @Mapper(componentModel = "spring")
 public interface GoalEntityMapper {
     @Mapping(target = "profileId", source = "profile.userId")
-    @Mapping(target = "description", ignore = true)
-    @Mapping(target = "colorHex", ignore = true)
-    @Mapping(target = "initialBalance", ignore = true)
+    @Mapping(target = "description", source = "description")
+    @Mapping(target = "colorHex", source = "colorHex")
+    @Mapping(target = "initialBalance", source = "initialBalance")
     @Mapping(target = "currentBalance", ignore = true)
     Goal toDomain(GoalEntity entity);
 
     @Mapping(target = "profile", ignore = true)
+    @Mapping(target = "description", source = "description")
+    @Mapping(target = "colorHex", source = "colorHex")
+    @Mapping(target = "initialBalance", source = "initialBalance")
     GoalEntity toEntity(Goal domain);
 
     List<Goal> toDomainList(List<GoalEntity> entities);

--- a/poupeai-core-persistence/src/main/resources/db/migration/V10__add_goal_columns.sql
+++ b/poupeai-core-persistence/src/main/resources/db/migration/V10__add_goal_columns.sql
@@ -1,0 +1,9 @@
+ALTER TABLE goals
+  ADD COLUMN description TEXT,
+  ADD COLUMN color_hex VARCHAR(20),
+  ADD COLUMN initial_balance DECIMAL(15,2) DEFAULT 0 NOT NULL;
+
+-- Backfill existing rows with defaults if needed
+UPDATE goals SET initial_balance = 0 WHERE initial_balance IS NULL;
+UPDATE goals SET description = '' WHERE description IS NULL;
+UPDATE goals SET color_hex = '#000000' WHERE color_hex IS NULL;

--- a/poupeai-core-persistence/src/test/java/io/github/poupeai/core/persistence/adapter/GoalRepositoryAdapterTest.java
+++ b/poupeai-core-persistence/src/test/java/io/github/poupeai/core/persistence/adapter/GoalRepositoryAdapterTest.java
@@ -40,6 +40,9 @@ class GoalRepositoryAdapterTest {
     @Mock
     private ProfileRepository profileRepository;
 
+    @Mock
+    private io.github.poupeai.core.persistence.repository.GoalDepositRepository goalDepositRepository;
+
     @Test
     @DisplayName("Should persist goal and link profile when data is valid")
     void createShouldPersistWhenDataIsValid() {

--- a/poupeai-core-web/src/main/java/io/github/poupeai/core/web/dto/goal/GoalRequest.java
+++ b/poupeai-core-web/src/main/java/io/github/poupeai/core/web/dto/goal/GoalRequest.java
@@ -19,6 +19,13 @@ public class GoalRequest {
     @NotBlank
     private String name;
     
+    private String description;
+
+    @NotBlank
+    private String colorHex;
+    
+    private BigDecimal initialBalance;
+
     @NotNull
     @Positive
     private BigDecimal goalAmount;

--- a/poupeai-core-web/src/main/java/io/github/poupeai/core/web/dto/goal/GoalResponse.java
+++ b/poupeai-core-web/src/main/java/io/github/poupeai/core/web/dto/goal/GoalResponse.java
@@ -17,7 +17,12 @@ import java.util.UUID;
 public class GoalResponse {
     private UUID id;
     private String name;
+    private String description;
+    private String colorHex;
+    private BigDecimal initialBalance;
     private BigDecimal goalAmount;
+    private BigDecimal currentBalance;
+    private BigDecimal percentageCompleted;
     private LocalDate targetDate;
     private LocalDate completedAt;
     private OffsetDateTime createdAt;

--- a/poupeai-core-web/src/main/java/io/github/poupeai/core/web/dto/goal/GoalUpdateRequest.java
+++ b/poupeai-core-web/src/main/java/io/github/poupeai/core/web/dto/goal/GoalUpdateRequest.java
@@ -15,7 +15,10 @@ import java.time.LocalDate;
 @AllArgsConstructor
 public class GoalUpdateRequest {
     private String name;
-    
+    private String description;
+    private String colorHex;
+    private BigDecimal initialBalance;
+
     @Positive
     private BigDecimal goalAmount;
     

--- a/poupeai-core-web/src/main/java/io/github/poupeai/core/web/mapper/goal/GoalControllerMapper.java
+++ b/poupeai-core-web/src/main/java/io/github/poupeai/core/web/mapper/goal/GoalControllerMapper.java
@@ -12,8 +12,10 @@ import org.mapstruct.NullValuePropertyMappingStrategy;
 
 import java.util.List;
 import java.util.UUID;
+import java.math.RoundingMode;
 
 @Mapper(componentModel = "spring")
+
 public interface GoalControllerMapper {
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "profileId", source = "profileId")
@@ -29,7 +31,24 @@ public interface GoalControllerMapper {
     @Mapping(target = "updatedAt", ignore = true)
     void updateDomainFromDto(GoalUpdateRequest dto, @MappingTarget Goal domain);
 
+    @Mapping(target = "description", source = "description")
+    @Mapping(target = "colorHex", source = "colorHex")
+    @Mapping(target = "initialBalance", source = "initialBalance")
+    @Mapping(target = "currentBalance", source = "currentBalance")
+    @Mapping(target = "percentageCompleted", expression = "java(calculatePercentage(domain))")
     GoalResponse toResponse(Goal domain);
     
     List<GoalResponse> toResponseList(List<Goal> goals);
+
+    default java.math.BigDecimal calculatePercentage(Goal domain) {
+        if (domain == null) {
+            return null;
+        }
+        java.math.BigDecimal goal = domain.getGoalAmount();
+        java.math.BigDecimal current = domain.getCurrentBalance();
+        if (goal == null || goal.compareTo(java.math.BigDecimal.ZERO) == 0 || current == null) {
+            return java.math.BigDecimal.ZERO;
+        }
+        return current.divide(goal, 4, RoundingMode.HALF_UP).multiply(new java.math.BigDecimal("100"));
+    }
 }


### PR DESCRIPTION
## Problema
A listagem de metas não retornava campos necessários para a UI (descrição, cor, saldo inicial, saldo atual e percentual concluído).

## O que foi feito
- Adicionada a devolução dos campos requisitados no `GoalResponse`.
- Implementado cálculo dinâmico de `currentBalance` = (initialBalance || 0) + soma(deposits).
- Implementado cálculo de `percentageCompleted` = currentBalance / goalAmount * 100.
- Atualizados mappers e adaptadores para popular os valores.
- Atualizado também os requisitos para edição e criação, visto que novos campos foram adicionados.