### PR TITLE
[Backend][core-service] 8.3 Adaptar endpoints GET para retornar o link do comprovante

### DIFF
--- a/src/main/java/io/github/poupeai/core/business/adapter/TransactionServiceAdapter.java
+++ b/src/main/java/io/github/poupeai/core/business/adapter/TransactionServiceAdapter.java
@@ -104,8 +104,10 @@ public class TransactionServiceAdapter implements TransactionServicePort {
 
     @Override
     public Transaction findByIdAndProfileId(UUID id, UUID profileId) {
-        return transactionRepositoryPort.findByIdAndProfileId(id, profileId)
+        Transaction t = transactionRepositoryPort.findByIdAndProfileId(id, profileId)
                 .orElseThrow(() -> new ResourceNotFoundException("Transação não encontrada."));
+        enrichWithUrl(t);
+        return t;
     }
 
     @Override
@@ -142,7 +144,10 @@ public class TransactionServiceAdapter implements TransactionServicePort {
         if (filter.getSortBy() == null || filter.getSortBy().isEmpty()) {
             filter.setSortBy("transactionDate");
         }
-        return transactionRepositoryPort.search(profileId, filter);
+        PageDomain<Transaction> page = transactionRepositoryPort.search(profileId, filter);
+
+        page.getContent().forEach(this::enrichWithUrl);
+        return page;
     }
 
     @Override
@@ -167,7 +172,9 @@ public class TransactionServiceAdapter implements TransactionServicePort {
         storagePort.upload(key, content, contentType, size, tags);
 
         Transaction updated = transaction.withAttachmentKey(key);
-        return transactionRepositoryPort.update(updated);
+        Transaction saved = transactionRepositoryPort.update(updated);
+        enrichWithUrl(saved);
+        return saved;
     }
 
     @Override
@@ -217,5 +224,11 @@ public class TransactionServiceAdapter implements TransactionServicePort {
 
     private TransactionType mapCategoryTypeToTransactionType(CategoryType categoryType) {
         return categoryType == CategoryType.INCOME ? TransactionType.INCOME : TransactionType.EXPENSE;
+    }
+
+    private void enrichWithUrl(Transaction t) {
+        if (t.getAttachmentKey() != null) {
+            t.setAttachmentUrl(storagePort.generatePresignedUrl(t.getAttachmentKey()));
+        }
     }
 }

--- a/src/main/java/io/github/poupeai/core/domain/model/Transaction.java
+++ b/src/main/java/io/github/poupeai/core/domain/model/Transaction.java
@@ -31,6 +31,7 @@ public class Transaction {
     private Category category;
     @With private UUID invoiceId;
     @With private String attachmentKey;
+    private String attachmentUrl;
 
     @Builder.Default
     private Boolean isInstallment = false;

--- a/src/main/java/io/github/poupeai/core/domain/port/output/StoragePort.java
+++ b/src/main/java/io/github/poupeai/core/domain/port/output/StoragePort.java
@@ -7,4 +7,6 @@ public interface StoragePort {
     void upload(String key, InputStream content, String contentType, long size, Map<String, String> tags);
 
     void delete(String key);
+
+    String generatePresignedUrl(String key);
 }

--- a/src/main/java/io/github/poupeai/core/persistence/adapter/MinioStorageAdapter.java
+++ b/src/main/java/io/github/poupeai/core/persistence/adapter/MinioStorageAdapter.java
@@ -2,10 +2,12 @@ package io.github.poupeai.core.persistence.adapter;
 
 import io.github.poupeai.core.domain.port.output.StoragePort;
 import io.minio.BucketExistsArgs;
+import io.minio.GetPresignedObjectUrlArgs;
 import io.minio.MakeBucketArgs;
 import io.minio.MinioClient;
 import io.minio.PutObjectArgs;
 import io.minio.RemoveObjectArgs;
+import io.minio.http.Method;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -94,6 +96,24 @@ public class MinioStorageAdapter implements StoragePort {
         } catch (Exception e) {
             log.error("Erro ao remover arquivo do MinIO: key='{}'", key, e);
             throw new RuntimeException("Falha ao remover arquivo do storage", e);
+        }
+    }
+
+    @Override
+    public String generatePresignedUrl(String key) {
+        if (key == null || key.isBlank()) return null;
+        try {
+            return getClient().getPresignedObjectUrl(
+                    GetPresignedObjectUrlArgs.builder()
+                            .method(Method.GET)
+                            .bucket(bucketName)
+                            .object(key)
+                            .expiry(900)
+                            .build()
+            );
+        } catch (Exception e) {
+            log.error("Erro ao gerar URL para key: {}", key, e);
+            return null;
         }
     }
 }

--- a/src/main/java/io/github/poupeai/core/web/dto/transaction/TransactionResponse.java
+++ b/src/main/java/io/github/poupeai/core/web/dto/transaction/TransactionResponse.java
@@ -29,6 +29,7 @@ public class TransactionResponse {
 
     private UUID invoiceId;
     private String attachmentKey;
+    private String attachmentUrl;
 
     private Boolean isInstallment;
     private Integer installmentNumber;


### PR DESCRIPTION
# O que foi feito

- Alteração do DTO de retorno da transação (GET) para incluir o campo attachmentUrl.
- Implementação da lógica no MinioAdapter para gerar URLs que expiram (ex: 15 minutos).
