### PR TITLE
[Backend][core-service] Configuração do gatilho para auditoria

### DIFF
--- a/src/main/java/io/github/poupeai/core/audit/ApplicationContextProvider.java
+++ b/src/main/java/io/github/poupeai/core/audit/ApplicationContextProvider.java
@@ -9,10 +9,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class ApplicationContextProvider implements ApplicationContextAware {
 
-    private static ApplicationContext applicationContext;
+    private static volatile ApplicationContext applicationContext;
 
     @Override
-    public void setApplicationContext(ApplicationContext context) throws BeansException {
+public void setApplicationContext(ApplicationContext context) throws BeansException {
         applicationContext = context;
     }
 

--- a/src/main/java/io/github/poupeai/core/audit/ApplicationContextProvider.java
+++ b/src/main/java/io/github/poupeai/core/audit/ApplicationContextProvider.java
@@ -1,0 +1,33 @@
+package io.github.poupeai.core.audit;
+
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
+
+
+@Component
+public class ApplicationContextProvider implements ApplicationContextAware {
+
+    private static ApplicationContext applicationContext;
+
+    @Override
+    public void setApplicationContext(ApplicationContext context) throws BeansException {
+        applicationContext = context;
+    }
+
+    public static ApplicationContext getApplicationContext() {
+        return applicationContext;
+    }
+
+    public static <T> T getBean(Class<T> beanClass) {
+        if (applicationContext == null) {
+            return null;
+        }
+        try {
+            return applicationContext.getBean(beanClass);
+        } catch (BeansException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/io/github/poupeai/core/audit/AuditContext.java
+++ b/src/main/java/io/github/poupeai/core/audit/AuditContext.java
@@ -1,0 +1,43 @@
+package io.github.poupeai.core.audit;
+
+import java.util.UUID;
+
+public final class AuditContext {
+
+    private AuditContext() {
+    }
+
+    private static final ThreadLocal<String> SOURCE_IP = new ThreadLocal<>();
+    private static final ThreadLocal<UUID> CORRELATION_ID = new ThreadLocal<>();
+    private static final ThreadLocal<String> USER_AGENT = new ThreadLocal<>();
+
+    public static void setSourceIp(String sourceIp) {
+        SOURCE_IP.set(sourceIp);
+    }
+
+    public static String getSourceIp() {
+        return SOURCE_IP.get();
+    }
+
+    public static void setCorrelationId(UUID correlationId) {
+        CORRELATION_ID.set(correlationId);
+    }
+
+    public static UUID getCorrelationId() {
+        return CORRELATION_ID.get();
+    }
+
+    public static void setUserAgent(String userAgent) {
+        USER_AGENT.set(userAgent);
+    }
+
+    public static String getUserAgent() {
+        return USER_AGENT.get();
+    }
+
+    public static void clear() {
+        SOURCE_IP.remove();
+        CORRELATION_ID.remove();
+        USER_AGENT.remove();
+    }
+}

--- a/src/main/java/io/github/poupeai/core/audit/AuditContextFilter.java
+++ b/src/main/java/io/github/poupeai/core/audit/AuditContextFilter.java
@@ -1,0 +1,63 @@
+package io.github.poupeai.core.audit;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 10)
+@Slf4j
+public class AuditContextFilter extends OncePerRequestFilter {
+
+    private static final String X_FORWARDED_FOR_HEADER = "X-Forwarded-For";
+    private static final String USER_AGENT_HEADER = "User-Agent";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            populateAuditContext(request);
+            filterChain.doFilter(request, response);
+        } finally {
+            AuditContext.clear();
+        }
+    }
+
+    private void populateAuditContext(HttpServletRequest request) {
+        try {
+            String sourceIp = request.getHeader(X_FORWARDED_FOR_HEADER);
+            if (sourceIp == null || sourceIp.isBlank()) {
+                sourceIp = request.getRemoteAddr();
+            } else {
+                sourceIp = sourceIp.split(",")[0].trim();
+            }
+            AuditContext.setSourceIp(sourceIp);
+
+            String userAgent = request.getHeader(USER_AGENT_HEADER);
+            if (userAgent != null) {
+                AuditContext.setUserAgent(userAgent.length() > 255 ? userAgent.substring(0, 255) : userAgent);
+            }
+
+            String traceId = MDC.get("traceId");
+            if (traceId != null && !traceId.isBlank()) {
+                try {
+                    AuditContext.setCorrelationId(UUID.fromString(traceId));
+                } catch (IllegalArgumentException e) {
+                    log.debug("TraceId não é um UUID válido: {}", traceId);
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Falha ao popular contexto de auditoria: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/io/github/poupeai/core/audit/ProfileAuditEvent.java
+++ b/src/main/java/io/github/poupeai/core/audit/ProfileAuditEvent.java
@@ -1,0 +1,13 @@
+package io.github.poupeai.core.audit;
+
+import java.util.Map;
+import java.util.UUID;
+
+public record ProfileAuditEvent(
+        UUID profileId,
+        String actionType,
+        String entityType,
+        Map<String, Object> changes,
+        String sourceIp,
+        UUID correlationId) {
+}

--- a/src/main/java/io/github/poupeai/core/audit/ProfileAuditEventHandler.java
+++ b/src/main/java/io/github/poupeai/core/audit/ProfileAuditEventHandler.java
@@ -1,0 +1,46 @@
+package io.github.poupeai.core.audit;
+
+import io.github.poupeai.core.persistence.entity.AuditLogEntity;
+import io.github.poupeai.core.persistence.repository.AuditLogRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.time.OffsetDateTime;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ProfileAuditEventHandler {
+
+    private static final String SERVICE_NAME = "poupeai-core-service";
+
+    private final AuditLogRepository auditLogRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleProfileAuditEvent(ProfileAuditEvent event) {
+        try {
+            AuditLogEntity auditLog = AuditLogEntity.builder()
+                    .profileId(event.profileId())
+                    .actionTime(OffsetDateTime.now())
+                    .actionType(event.actionType())
+                    .entityType(event.entityType())
+                    .entityId(event.profileId() != null ? event.profileId().toString() : "unknown")
+                    .changes(event.changes())
+                    .sourceIp(event.sourceIp())
+                    .correlationId(event.correlationId())
+                    .serviceName(SERVICE_NAME)
+                    .build();
+
+            auditLogRepository.save(auditLog);
+            log.info("Auditoria de perfil criada para ação: {}, profile_id: {}", event.actionType(), event.profileId());
+        } catch (Exception e) {
+            log.error("Falha ao criar log de auditoria para Profile {}: {}", event.actionType(), e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/io/github/poupeai/core/audit/ProfileAuditListener.java
+++ b/src/main/java/io/github/poupeai/core/audit/ProfileAuditListener.java
@@ -7,18 +7,20 @@ import jakarta.persistence.PostRemove;
 import jakarta.persistence.PostUpdate;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.WeakHashMap;
 
 @Slf4j
 public class ProfileAuditListener {
 
     private static final String ENTITY_TYPE = "Profile";
 
-    private static final Map<UUID, Map<String, Object>> OLD_VALUES_CACHE = new ConcurrentHashMap<>();
+    private static final Map<UUID, Map<String, Object>> OLD_VALUES_CACHE =
+            Collections.synchronizedMap(new WeakHashMap<>());
 
     @PostLoad
     public void postLoad(ProfileEntity entity) {
@@ -38,25 +40,31 @@ public class ProfileAuditListener {
             log.info("Evento de auditoria publicado para ação: CREATE, profile_id: {}", entity.getUserId());
         } catch (Exception e) {
             log.error("Falha ao publicar evento de auditoria para Profile CREATE: {}", e.getMessage(), e);
+            // Clean up any cached state for this entity to avoid stale data on failed CREATE operations
+            if (entity != null && entity.getUserId() != null) {
+                OLD_VALUES_CACHE.remove(entity.getUserId());
+            }
         }
     }
 
     @PostUpdate
     public void postUpdate(ProfileEntity entity) {
         try {
-            Map<String, Object> oldValues = OLD_VALUES_CACHE.get(entity.getUserId());
-            Map<String, Object> changes = detectChanges(oldValues, captureEntityState(entity));
+            OLD_VALUES_CACHE.compute(entity.getUserId(), (id, oldValues) -> {
+                Map<String, Object> newState = captureEntityState(entity);
+                Map<String, Object> changes = detectChanges(oldValues, newState);
 
-            if (changes.isEmpty()) {
-                log.debug("Sem mudanças detectadas no perfil: {}", entity.getUserId());
-                return;
-            }
+                if (changes.isEmpty()) {
+                    log.debug("Sem mudanças detectadas no perfil: {}", entity.getUserId());
+                    return newState;
+                }
 
-            publishAuditEvent(entity, "UPDATE", changes);
-            log.info("Evento de auditoria publicado para ação: UPDATE, profile_id: {}, changes: {}",
-                    entity.getUserId(), changes.keySet());
+                publishAuditEvent(entity, "UPDATE", changes);
+                log.info("Evento de auditoria publicado para ação: UPDATE, profile_id: {}, changes: {}",
+                        entity.getUserId(), changes.keySet());
 
-            OLD_VALUES_CACHE.put(entity.getUserId(), captureEntityState(entity));
+                return newState;
+            });
         } catch (Exception e) {
             log.error("Falha ao publicar evento de auditoria para Profile UPDATE: {}", e.getMessage(), e);
         }

--- a/src/main/java/io/github/poupeai/core/audit/ProfileAuditListener.java
+++ b/src/main/java/io/github/poupeai/core/audit/ProfileAuditListener.java
@@ -1,0 +1,130 @@
+package io.github.poupeai.core.audit;
+
+import io.github.poupeai.core.persistence.entity.ProfileEntity;
+import jakarta.persistence.PostLoad;
+import jakarta.persistence.PostPersist;
+import jakarta.persistence.PostRemove;
+import jakarta.persistence.PostUpdate;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+public class ProfileAuditListener {
+
+    private static final String ENTITY_TYPE = "Profile";
+
+    private static final Map<UUID, Map<String, Object>> OLD_VALUES_CACHE = new ConcurrentHashMap<>();
+
+    @PostLoad
+    public void postLoad(ProfileEntity entity) {
+        try {
+            if (entity.getUserId() != null) {
+                OLD_VALUES_CACHE.put(entity.getUserId(), captureEntityState(entity));
+            }
+        } catch (Exception e) {
+            log.debug("Falha ao capturar estado da entidade no load: {}", e.getMessage());
+        }
+    }
+
+    @PostPersist
+    public void postPersist(ProfileEntity entity) {
+        try {
+            publishAuditEvent(entity, "CREATE", null);
+            log.info("Evento de auditoria publicado para ação: CREATE, profile_id: {}", entity.getUserId());
+        } catch (Exception e) {
+            log.error("Falha ao publicar evento de auditoria para Profile CREATE: {}", e.getMessage(), e);
+        }
+    }
+
+    @PostUpdate
+    public void postUpdate(ProfileEntity entity) {
+        try {
+            Map<String, Object> oldValues = OLD_VALUES_CACHE.get(entity.getUserId());
+            Map<String, Object> changes = detectChanges(oldValues, captureEntityState(entity));
+
+            if (changes.isEmpty()) {
+                log.debug("Sem mudanças detectadas no perfil: {}", entity.getUserId());
+                return;
+            }
+
+            publishAuditEvent(entity, "UPDATE", changes);
+            log.info("Evento de auditoria publicado para ação: UPDATE, profile_id: {}, changes: {}",
+                    entity.getUserId(), changes.keySet());
+
+            OLD_VALUES_CACHE.put(entity.getUserId(), captureEntityState(entity));
+        } catch (Exception e) {
+            log.error("Falha ao publicar evento de auditoria para Profile UPDATE: {}", e.getMessage(), e);
+        }
+    }
+
+    @PostRemove
+    public void postRemove(ProfileEntity entity) {
+        try {
+            publishAuditEvent(entity, "DELETE", null);
+            log.info("Evento de auditoria publicado para ação: DELETE, profile_id: {}", entity.getUserId());
+
+            OLD_VALUES_CACHE.remove(entity.getUserId());
+        } catch (Exception e) {
+            log.error("Falha ao publicar evento de auditoria para Profile DELETE: {}", e.getMessage(), e);
+        }
+    }
+
+    private void publishAuditEvent(ProfileEntity entity, String actionType, Map<String, Object> changes) {
+        var context = ApplicationContextProvider.getApplicationContext();
+        if (context == null) {
+            log.warn("ApplicationContext não disponível, pulando publicação de evento de auditoria");
+            return;
+        }
+
+        ProfileAuditEvent event = new ProfileAuditEvent(
+                entity.getUserId(),
+                actionType,
+                ENTITY_TYPE,
+                changes,
+                AuditContext.getSourceIp(),
+                AuditContext.getCorrelationId());
+
+        context.publishEvent(event);
+    }
+
+    private Map<String, Object> captureEntityState(ProfileEntity entity) {
+        Map<String, Object> state = new HashMap<>();
+        state.put("email", entity.getEmail());
+        state.put("firstName", entity.getFirstName());
+        state.put("lastName", entity.getLastName());
+        state.put("isDeactivated", entity.isDeactivated());
+        state.put("deactivationScheduledAt",
+                entity.getDeactivationScheduledAt() != null
+                        ? entity.getDeactivationScheduledAt().toString()
+                        : null);
+        return state;
+    }
+
+    private Map<String, Object> detectChanges(Map<String, Object> oldValues, Map<String, Object> newValues) {
+        Map<String, Object> changes = new HashMap<>();
+
+        if (oldValues == null) {
+            return changes;
+        }
+
+        for (Map.Entry<String, Object> entry : newValues.entrySet()) {
+            String field = entry.getKey();
+            Object newValue = entry.getValue();
+            Object oldValue = oldValues.get(field);
+
+            if (!Objects.equals(oldValue, newValue)) {
+                changes.put(field, new Object[] {
+                        oldValue != null ? oldValue.toString() : null,
+                        newValue != null ? newValue.toString() : null
+                });
+            }
+        }
+
+        return changes;
+    }
+}

--- a/src/main/java/io/github/poupeai/core/domain/model/AuditLog.java
+++ b/src/main/java/io/github/poupeai/core/domain/model/AuditLog.java
@@ -1,0 +1,27 @@
+package io.github.poupeai.core.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuditLog {
+    private Long id;
+    private UUID profileId;
+    private OffsetDateTime actionTime;
+    private String actionType;
+    private String entityType;
+    private String entityId;
+    private Map<String, Object> changes;
+    private String sourceIp;
+    private UUID correlationId;
+    private String serviceName;
+}

--- a/src/main/java/io/github/poupeai/core/domain/port/persistence/AuditLogRepositoryPort.java
+++ b/src/main/java/io/github/poupeai/core/domain/port/persistence/AuditLogRepositoryPort.java
@@ -1,0 +1,7 @@
+package io.github.poupeai.core.domain.port.persistence;
+
+import io.github.poupeai.core.domain.model.AuditLog;
+
+public interface AuditLogRepositoryPort {
+    AuditLog save(AuditLog auditLog);
+}

--- a/src/main/java/io/github/poupeai/core/persistence/adapter/AuditLogRepositoryAdapter.java
+++ b/src/main/java/io/github/poupeai/core/persistence/adapter/AuditLogRepositoryAdapter.java
@@ -1,0 +1,30 @@
+package io.github.poupeai.core.persistence.adapter;
+
+import io.github.poupeai.core.domain.model.AuditLog;
+import io.github.poupeai.core.domain.port.persistence.AuditLogRepositoryPort;
+import io.github.poupeai.core.persistence.mapper.AuditLogEntityMapper;
+import io.github.poupeai.core.persistence.repository.AuditLogRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class AuditLogRepositoryAdapter implements AuditLogRepositoryPort {
+    private final AuditLogRepository repository;
+    private final AuditLogEntityMapper mapper;
+
+    @Override
+    public AuditLog save(AuditLog auditLog) {
+        try {
+            var entity = mapper.toEntity(auditLog);
+            var savedEntity = repository.save(entity);
+            return mapper.toDomain(savedEntity);
+        } catch (Exception e) {
+            log.error("Falha ao salvar log de auditoria para entidade {} com id {}: {}",
+                    auditLog.getEntityType(), auditLog.getEntityId(), e.getMessage(), e);
+            return null;
+        }
+    }
+}

--- a/src/main/java/io/github/poupeai/core/persistence/entity/AuditLogEntity.java
+++ b/src/main/java/io/github/poupeai/core/persistence/entity/AuditLogEntity.java
@@ -1,0 +1,59 @@
+package io.github.poupeai.core.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+@Entity
+@Table(name = "audit_logs")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuditLogEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "profile_id")
+    private UUID profileId;
+
+    @Column(name = "action_time", nullable = false)
+    @Builder.Default
+    private OffsetDateTime actionTime = OffsetDateTime.now();
+
+    @Column(name = "action_type", nullable = false, length = 50)
+    private String actionType;
+
+    @Column(name = "entity_type", nullable = false, length = 100)
+    private String entityType;
+
+    @Column(name = "entity_id", nullable = false, length = 36)
+    private String entityId;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "changes", columnDefinition = "jsonb")
+    private Map<String, Object> changes;
+
+    @Column(name = "source_ip", length = 45)
+    private String sourceIp;
+
+    @Column(name = "correlation_id")
+    private UUID correlationId;
+
+    @Column(name = "service_name", nullable = false, length = 50)
+    private String serviceName;
+}

--- a/src/main/java/io/github/poupeai/core/persistence/entity/ProfileEntity.java
+++ b/src/main/java/io/github/poupeai/core/persistence/entity/ProfileEntity.java
@@ -1,7 +1,9 @@
 package io.github.poupeai.core.persistence.entity;
 
+import io.github.poupeai.core.audit.ProfileAuditListener;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
@@ -16,6 +18,7 @@ import java.util.UUID;
 
 @Entity
 @Table(name = "profiles")
+@EntityListeners(ProfileAuditListener.class)
 @Data
 @Builder
 @NoArgsConstructor

--- a/src/main/java/io/github/poupeai/core/persistence/mapper/AuditLogEntityMapper.java
+++ b/src/main/java/io/github/poupeai/core/persistence/mapper/AuditLogEntityMapper.java
@@ -1,0 +1,12 @@
+package io.github.poupeai.core.persistence.mapper;
+
+import io.github.poupeai.core.domain.model.AuditLog;
+import io.github.poupeai.core.persistence.entity.AuditLogEntity;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface AuditLogEntityMapper {
+    AuditLogEntity toEntity(AuditLog domain);
+
+    AuditLog toDomain(AuditLogEntity entity);
+}

--- a/src/main/java/io/github/poupeai/core/persistence/repository/AuditLogRepository.java
+++ b/src/main/java/io/github/poupeai/core/persistence/repository/AuditLogRepository.java
@@ -1,0 +1,7 @@
+package io.github.poupeai.core.persistence.repository;
+
+import io.github.poupeai.core.persistence.entity.AuditLogEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AuditLogRepository extends JpaRepository<AuditLogEntity, Long> {
+}

--- a/src/main/resources/db/migration/V13__create_table_audit_logs.sql
+++ b/src/main/resources/db/migration/V13__create_table_audit_logs.sql
@@ -4,7 +4,7 @@ CREATE TABLE audit_logs (
     action_time TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     action_type VARCHAR(50) NOT NULL,
     entity_type VARCHAR(100) NOT NULL,
-    entity_id VARCHAR(36) NOT NULL,
+    entity_id VARCHAR(255) NOT NULL,
     changes JSONB,
     source_ip VARCHAR(45),
     correlation_id UUID,

--- a/src/main/resources/db/migration/V13__create_table_audit_logs.sql
+++ b/src/main/resources/db/migration/V13__create_table_audit_logs.sql
@@ -14,3 +14,4 @@ CREATE TABLE audit_logs (
 CREATE INDEX idx_audit_logs_profile_id ON audit_logs(profile_id);
 CREATE INDEX idx_audit_logs_action_time ON audit_logs(action_time);
 CREATE INDEX idx_audit_logs_entity_type ON audit_logs(entity_type);
+CREATE INDEX idx_audit_logs_correlation_id ON audit_logs(correlation_id);

--- a/src/main/resources/db/migration/V13__create_table_audit_logs.sql
+++ b/src/main/resources/db/migration/V13__create_table_audit_logs.sql
@@ -1,0 +1,16 @@
+CREATE TABLE audit_logs (
+    id BIGSERIAL PRIMARY KEY,
+    profile_id UUID REFERENCES profiles(user_id) ON DELETE SET NULL,
+    action_time TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    action_type VARCHAR(50) NOT NULL,
+    entity_type VARCHAR(100) NOT NULL,
+    entity_id VARCHAR(36) NOT NULL,
+    changes JSONB,
+    source_ip VARCHAR(45),
+    correlation_id UUID,
+    service_name VARCHAR(50) NOT NULL
+);
+
+CREATE INDEX idx_audit_logs_profile_id ON audit_logs(profile_id);
+CREATE INDEX idx_audit_logs_action_time ON audit_logs(action_time);
+CREATE INDEX idx_audit_logs_entity_type ON audit_logs(entity_type);

--- a/src/test/java/io/github/poupeai/core/audit/AuditContextFilterTest.java
+++ b/src/test/java/io/github/poupeai/core/audit/AuditContextFilterTest.java
@@ -1,0 +1,101 @@
+package io.github.poupeai.core.audit;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.slf4j.MDC;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class AuditContextFilterTest {
+
+    private AuditContextFilter filter;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @BeforeEach
+    void setUp() {
+        filter = new AuditContextFilter();
+    }
+
+    @AfterEach
+    void tearDown() {
+        AuditContext.clear();
+        MDC.clear();
+    }
+
+    @Test
+    @DisplayName("Should extract source IP from X-Forwarded-For header")
+    void shouldExtractForwardedForHeader() throws Exception {
+        when(request.getHeader("X-Forwarded-For")).thenReturn("192.168.1.100, 10.0.0.1");
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("Should use remote addr when X-Forwarded-For is not present")
+    void shouldUseRemoteAddrWhenNoForwardedFor() throws Exception {
+        when(request.getHeader("X-Forwarded-For")).thenReturn(null);
+        when(request.getRemoteAddr()).thenReturn("192.168.1.1");
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("Should truncate long User-Agent headers")
+    void shouldTruncateLongUserAgent() throws Exception {
+        String longUserAgent = "A".repeat(300);
+        when(request.getHeader("User-Agent")).thenReturn(longUserAgent);
+        when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("Should clear context after filter chain completes")
+    void shouldClearContextAfterFilterChain() throws Exception {
+        when(request.getRemoteAddr()).thenReturn("192.168.1.1");
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        assertNull(AuditContext.getSourceIp());
+        assertNull(AuditContext.getCorrelationId());
+    }
+
+    @Test
+    @DisplayName("Should clear context even when exception occurs in filter chain")
+    void shouldClearContextOnException() throws Exception {
+        when(request.getRemoteAddr()).thenReturn("192.168.1.1");
+        doThrow(new RuntimeException("Test exception")).when(filterChain).doFilter(request, response);
+
+        assertThrows(RuntimeException.class, () -> filter.doFilterInternal(request, response, filterChain));
+
+        assertNull(AuditContext.getSourceIp());
+        assertNull(AuditContext.getCorrelationId());
+    }
+}

--- a/src/test/java/io/github/poupeai/core/audit/ProfileAuditEventHandlerTest.java
+++ b/src/test/java/io/github/poupeai/core/audit/ProfileAuditEventHandlerTest.java
@@ -1,0 +1,110 @@
+package io.github.poupeai.core.audit;
+
+import io.github.poupeai.core.persistence.entity.AuditLogEntity;
+import io.github.poupeai.core.persistence.repository.AuditLogRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileAuditEventHandlerTest {
+
+    @InjectMocks
+    private ProfileAuditEventHandler handler;
+
+    @Mock
+    private AuditLogRepository auditLogRepository;
+
+    @Test
+    @DisplayName("Should save audit log when handling CREATE event")
+    void handleProfileAuditEvent_shouldSaveAuditLog() {
+        UUID profileId = UUID.randomUUID();
+        UUID correlationId = UUID.randomUUID();
+        String sourceIp = "192.168.1.1";
+
+        ProfileAuditEvent event = new ProfileAuditEvent(
+                profileId,
+                "CREATE",
+                "Profile",
+                null,
+                sourceIp,
+                correlationId);
+
+        when(auditLogRepository.save(any(AuditLogEntity.class))).thenAnswer(i -> {
+            AuditLogEntity entity = i.getArgument(0);
+            entity.setId(1L);
+            return entity;
+        });
+
+        handler.handleProfileAuditEvent(event);
+
+        ArgumentCaptor<AuditLogEntity> captor = ArgumentCaptor.forClass(AuditLogEntity.class);
+        verify(auditLogRepository).save(captor.capture());
+
+        AuditLogEntity savedLog = captor.getValue();
+        assertEquals("CREATE", savedLog.getActionType());
+        assertEquals("Profile", savedLog.getEntityType());
+        assertEquals(profileId, savedLog.getProfileId());
+        assertEquals(profileId.toString(), savedLog.getEntityId());
+        assertEquals(sourceIp, savedLog.getSourceIp());
+        assertEquals(correlationId, savedLog.getCorrelationId());
+        assertEquals("poupeai-core-service", savedLog.getServiceName());
+    }
+
+    @Test
+    @DisplayName("Should save audit log with changes for UPDATE event")
+    void handleProfileAuditEvent_shouldSaveChangesForUpdate() {
+        UUID profileId = UUID.randomUUID();
+        Map<String, Object> changes = Map.of(
+                "firstName", new Object[] { "Old", "New" },
+                "email", new Object[] { "old@test.com", "new@test.com" });
+
+        ProfileAuditEvent event = new ProfileAuditEvent(
+                profileId,
+                "UPDATE",
+                "Profile",
+                changes,
+                null,
+                null);
+
+        when(auditLogRepository.save(any(AuditLogEntity.class))).thenAnswer(i -> i.getArgument(0));
+
+        handler.handleProfileAuditEvent(event);
+
+        ArgumentCaptor<AuditLogEntity> captor = ArgumentCaptor.forClass(AuditLogEntity.class);
+        verify(auditLogRepository).save(captor.capture());
+
+        AuditLogEntity savedLog = captor.getValue();
+        assertEquals("UPDATE", savedLog.getActionType());
+        assertNotNull(savedLog.getChanges());
+        assertEquals(2, savedLog.getChanges().size());
+    }
+
+    @Test
+    @DisplayName("Should not throw when repository fails")
+    void handleProfileAuditEvent_shouldNotThrowOnRepositoryError() {
+        ProfileAuditEvent event = new ProfileAuditEvent(
+                UUID.randomUUID(),
+                "CREATE",
+                "Profile",
+                null,
+                null,
+                null);
+
+        when(auditLogRepository.save(any(AuditLogEntity.class)))
+                .thenThrow(new RuntimeException("Database error"));
+
+        assertDoesNotThrow(() -> handler.handleProfileAuditEvent(event));
+    }
+}

--- a/src/test/java/io/github/poupeai/core/audit/ProfileAuditListenerTest.java
+++ b/src/test/java/io/github/poupeai/core/audit/ProfileAuditListenerTest.java
@@ -1,0 +1,183 @@
+package io.github.poupeai.core.audit;
+
+import io.github.poupeai.core.persistence.entity.ProfileEntity;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.context.ApplicationContext;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ProfileAuditListenerTest {
+
+    private ProfileAuditListener listener;
+
+    @Mock
+    private ApplicationContext applicationContext;
+
+    private MockedStatic<ApplicationContextProvider> applicationContextProviderMock;
+
+    @BeforeEach
+    void setUp() {
+        listener = new ProfileAuditListener();
+        applicationContextProviderMock = Mockito.mockStatic(ApplicationContextProvider.class);
+        applicationContextProviderMock.when(ApplicationContextProvider::getApplicationContext)
+                .thenReturn(applicationContext);
+    }
+
+    @AfterEach
+    void tearDown() {
+        applicationContextProviderMock.close();
+        AuditContext.clear();
+    }
+
+    @Test
+    @DisplayName("Should publish audit event on profile creation")
+    void postPersist_shouldPublishEventForCreate() {
+        UUID userId = UUID.randomUUID();
+        ProfileEntity entity = createProfileEntity(userId);
+
+        listener.postPersist(entity);
+
+        ArgumentCaptor<ProfileAuditEvent> captor = ArgumentCaptor.forClass(ProfileAuditEvent.class);
+        verify(applicationContext).publishEvent(captor.capture());
+
+        ProfileAuditEvent event = captor.getValue();
+        assertEquals("CREATE", event.actionType());
+        assertEquals("Profile", event.entityType());
+        assertEquals(userId, event.profileId());
+        assertNull(event.changes());
+    }
+
+    @Test
+    @DisplayName("Should publish audit event on profile deletion")
+    void postRemove_shouldPublishEventForDelete() {
+        UUID userId = UUID.randomUUID();
+        ProfileEntity entity = createProfileEntity(userId);
+
+        listener.postRemove(entity);
+
+        ArgumentCaptor<ProfileAuditEvent> captor = ArgumentCaptor.forClass(ProfileAuditEvent.class);
+        verify(applicationContext).publishEvent(captor.capture());
+
+        ProfileAuditEvent event = captor.getValue();
+        assertEquals("DELETE", event.actionType());
+        assertEquals("Profile", event.entityType());
+        assertEquals(userId, event.profileId());
+    }
+
+    @Test
+    @DisplayName("Should capture context in audit event")
+    void postPersist_shouldCaptureAuditContext() {
+        UUID userId = UUID.randomUUID();
+        UUID correlationId = UUID.randomUUID();
+        String sourceIp = "192.168.1.1";
+
+        AuditContext.setSourceIp(sourceIp);
+        AuditContext.setCorrelationId(correlationId);
+
+        ProfileEntity entity = createProfileEntity(userId);
+
+        listener.postPersist(entity);
+
+        ArgumentCaptor<ProfileAuditEvent> captor = ArgumentCaptor.forClass(ProfileAuditEvent.class);
+        verify(applicationContext).publishEvent(captor.capture());
+
+        ProfileAuditEvent event = captor.getValue();
+        assertEquals(sourceIp, event.sourceIp());
+        assertEquals(correlationId, event.correlationId());
+    }
+
+    @Test
+    @DisplayName("Should detect changes on profile update")
+    void postUpdate_shouldDetectChanges() {
+        UUID userId = UUID.randomUUID();
+        ProfileEntity entity = ProfileEntity.builder()
+                .userId(userId)
+                .email("old@example.com")
+                .firstName("OldFirst")
+                .lastName("OldLast")
+                .isDeactivated(false)
+                .build();
+
+        listener.postLoad(entity);
+
+        entity.setEmail("new@example.com");
+        entity.setFirstName("NewFirst");
+
+        listener.postUpdate(entity);
+
+        ArgumentCaptor<ProfileAuditEvent> captor = ArgumentCaptor.forClass(ProfileAuditEvent.class);
+        verify(applicationContext).publishEvent(captor.capture());
+
+        ProfileAuditEvent event = captor.getValue();
+        assertEquals("UPDATE", event.actionType());
+        assertNotNull(event.changes());
+        assertTrue(event.changes().containsKey("email"));
+        assertTrue(event.changes().containsKey("firstName"));
+        assertFalse(event.changes().containsKey("lastName"));
+    }
+
+    @Test
+    @DisplayName("Should not fail when context is unavailable")
+    void postPersist_shouldNotFailWhenContextUnavailable() {
+        applicationContextProviderMock.when(ApplicationContextProvider::getApplicationContext)
+                .thenReturn(null);
+
+        UUID userId = UUID.randomUUID();
+        ProfileEntity entity = createProfileEntity(userId);
+
+        assertDoesNotThrow(() -> listener.postPersist(entity));
+        verify(applicationContext, never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("Should not fail when publishing throws exception")
+    void postPersist_shouldNotFailWhenPublishingThrowsException() {
+        UUID userId = UUID.randomUUID();
+        ProfileEntity entity = createProfileEntity(userId);
+
+        doThrow(new RuntimeException("Event publishing error")).when(applicationContext).publishEvent(any());
+
+        assertDoesNotThrow(() -> listener.postPersist(entity));
+    }
+
+    @Test
+    @DisplayName("Should skip update event when no changes detected")
+    void postUpdate_shouldSkipWhenNoChanges() {
+        UUID userId = UUID.randomUUID();
+        ProfileEntity entity = createProfileEntity(userId);
+
+        listener.postLoad(entity);
+
+
+        listener.postUpdate(entity);
+
+        verify(applicationContext, never()).publishEvent(any());
+    }
+
+    private ProfileEntity createProfileEntity(UUID userId) {
+        return ProfileEntity.builder()
+                .userId(userId)
+                .email("test@example.com")
+                .firstName("Test")
+                .lastName("User")
+                .isDeactivated(false)
+                .build();
+    }
+}

--- a/src/test/java/io/github/poupeai/core/persistence/adapter/AuditLogRepositoryAdapterTest.java
+++ b/src/test/java/io/github/poupeai/core/persistence/adapter/AuditLogRepositoryAdapterTest.java
@@ -1,0 +1,99 @@
+package io.github.poupeai.core.persistence.adapter;
+
+import io.github.poupeai.core.domain.model.AuditLog;
+import io.github.poupeai.core.persistence.entity.AuditLogEntity;
+import io.github.poupeai.core.persistence.mapper.AuditLogEntityMapper;
+import io.github.poupeai.core.persistence.repository.AuditLogRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuditLogRepositoryAdapterTest {
+
+    @InjectMocks
+    private AuditLogRepositoryAdapter adapter;
+
+    @Mock
+    private AuditLogRepository repository;
+
+    @Mock
+    private AuditLogEntityMapper mapper;
+
+    @Test
+    @DisplayName("Should save audit log and return domain object")
+    void save_shouldPersistAndReturnDomain() {
+        UUID profileId = UUID.randomUUID();
+        AuditLog domainLog = createAuditLog(profileId);
+        AuditLogEntity entity = createAuditLogEntity(profileId);
+        AuditLogEntity savedEntity = createAuditLogEntity(profileId);
+        savedEntity.setId(1L);
+        AuditLog savedDomain = createAuditLog(profileId);
+        savedDomain.setId(1L);
+
+        when(mapper.toEntity(domainLog)).thenReturn(entity);
+        when(repository.save(entity)).thenReturn(savedEntity);
+        when(mapper.toDomain(savedEntity)).thenReturn(savedDomain);
+
+        AuditLog result = adapter.save(domainLog);
+
+        assertNotNull(result);
+        assertEquals(1L, result.getId());
+        verify(mapper).toEntity(domainLog);
+        verify(repository).save(entity);
+        verify(mapper).toDomain(savedEntity);
+    }
+
+    @Test
+    @DisplayName("Should return null and log error when exception occurs")
+    void save_shouldReturnNullOnException() {
+        UUID profileId = UUID.randomUUID();
+        AuditLog domainLog = createAuditLog(profileId);
+        AuditLogEntity entity = createAuditLogEntity(profileId);
+
+        when(mapper.toEntity(domainLog)).thenReturn(entity);
+        when(repository.save(entity)).thenThrow(new RuntimeException("Database error"));
+
+        AuditLog result = adapter.save(domainLog);
+
+        assertNull(result);
+        verify(mapper).toEntity(domainLog);
+        verify(repository).save(entity);
+        verify(mapper, never()).toDomain(any());
+    }
+
+    private AuditLog createAuditLog(UUID profileId) {
+        return AuditLog.builder()
+                .profileId(profileId)
+                .actionTime(OffsetDateTime.now())
+                .actionType("CREATE")
+                .entityType("Profile")
+                .entityId(profileId.toString())
+                .changes(Map.of())
+                .serviceName("poupeai-core-service")
+                .build();
+    }
+
+    private AuditLogEntity createAuditLogEntity(UUID profileId) {
+        return AuditLogEntity.builder()
+                .profileId(profileId)
+                .actionTime(OffsetDateTime.now())
+                .actionType("CREATE")
+                .entityType("Profile")
+                .entityId(profileId.toString())
+                .changes(Map.of())
+                .serviceName("poupeai-core-service")
+                .build();
+    }
+}


### PR DESCRIPTION
O trigger foi implementado na aplicação.
Operações diretas no banco não são auditadas, apenas por meio da aplicação.
Erros na auditoria são logados mas não mandam exceções.
Em caso de UPDATE, as mudanças são salvas em changes, no seguinte formato: {"campo": ["valorAntigo", "valorNovo"]}  


<img width="1012" height="248" alt="image" src="https://github.com/user-attachments/assets/c47226d1-35c5-4105-a573-69395241037f" />
<img width="1082" height="410" alt="image" src="https://github.com/user-attachments/assets/555ca9e6-e5ec-462d-b373-6aac574de850" />
<img width="975" height="101" alt="image" src="https://github.com/user-attachments/assets/a3a61876-bf11-4419-bf1d-a4a3e4e89f25" />
<img width="447" height="104" alt="image" src="https://github.com/user-attachments/assets/7aa85192-05d3-438d-84a6-d47994ad7c3d" />

Resolves #37 