### PR TITLE
[Backend][core-service] Funcionalidade de desativar/reativar perfil e agendador de limpeza de perfis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,12 @@
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
+		
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-admin-client</artifactId>
+			<version>26.0.8</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/io/github/poupeai/core/application/scheduler/ProfileDeletionScheduler.java
+++ b/src/main/java/io/github/poupeai/core/application/scheduler/ProfileDeletionScheduler.java
@@ -1,0 +1,25 @@
+package io.github.poupeai.core.application.scheduler;
+
+import io.github.poupeai.core.domain.port.business.ProfileServicePort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ProfileDeletionScheduler {
+    private final ProfileServicePort profileServicePort;
+
+    @Scheduled(cron = "${app.scheduler.profile.deletion-cron}")
+    public void processExpiredProfiles() {
+        log.info("Iniciando processamento de exclusão permanente de perfis expirados");
+        try {
+            profileServicePort.hardDeleteExpiredProfiles();
+        } catch (Exception e) {
+            log.error("Erro durante execução do processamento de exclusão de perfis: {}", e.getMessage(), e);
+        }
+        log.info("Processamento de exclusão permanente de perfis finalizado");
+    }
+}

--- a/src/main/java/io/github/poupeai/core/audit/ProfileAuditEventHandler.java
+++ b/src/main/java/io/github/poupeai/core/audit/ProfileAuditEventHandler.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.time.OffsetDateTime;
+import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -25,8 +26,10 @@ public class ProfileAuditEventHandler {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleProfileAuditEvent(ProfileAuditEvent event) {
         try {
+            UUID profileIdForLog = "DELETE".equals(event.actionType()) ? null : event.profileId();
+
             AuditLogEntity auditLog = AuditLogEntity.builder()
-                    .profileId(event.profileId())
+                    .profileId(profileIdForLog)
                     .actionTime(OffsetDateTime.now())
                     .actionType(event.actionType())
                     .entityType(event.entityType())

--- a/src/main/java/io/github/poupeai/core/business/adapter/ProfileServiceAdapter.java
+++ b/src/main/java/io/github/poupeai/core/business/adapter/ProfileServiceAdapter.java
@@ -1,0 +1,159 @@
+package io.github.poupeai.core.business.adapter;
+
+import io.github.poupeai.core.domain.event.PoupeAiEvent;
+import io.github.poupeai.core.domain.exception.DomainException;
+import io.github.poupeai.core.domain.exception.ResourceNotFoundException;
+import io.github.poupeai.core.domain.model.Profile;
+import io.github.poupeai.core.domain.model.ProfileNotificationData;
+import io.github.poupeai.core.domain.port.business.ProfileServicePort;
+import io.github.poupeai.core.domain.port.external.KeycloakUserPort;
+import io.github.poupeai.core.domain.port.messaging.ProfileNotificationProducerPort;
+import io.github.poupeai.core.domain.port.persistence.ProfileRepositoryPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ProfileServiceAdapter implements ProfileServicePort {
+    private static final int DELETION_GRACE_PERIOD_DAYS = 30;
+    private static final String REACTIVATE_ACCOUNT_DEEP_LINK = "poupeai://app/reactivate-account";
+
+    private final ProfileRepositoryPort profileRepositoryPort;
+    private final ProfileNotificationProducerPort profileNotificationProducerPort;
+    private final KeycloakUserPort keycloakUserPort;
+
+    @Override
+    @Transactional
+    public void deactivate(UUID userId) {
+        log.info("Iniciando desativação do perfil para userId: {}", userId);
+
+        Profile profile = profileRepositoryPort.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("Perfil não encontrado"));
+
+        if (profile.isDeactivated()) {
+            log.warn("Tentativa de desativar perfil já desativado: {}", userId);
+            throw new DomainException("Perfil já está desativado ou possui exclusão agendada.");
+        }
+
+        OffsetDateTime deletionScheduledAt = OffsetDateTime.now().plusDays(DELETION_GRACE_PERIOD_DAYS);
+        profile.setDeactivated(true);
+        profile.setDeactivationScheduledAt(deletionScheduledAt);
+
+        profileRepositoryPort.save(profile);
+        log.info("Perfil desativado com sucesso. Exclusão agendada para: {}", deletionScheduledAt);
+
+        publishDeletionScheduledEvent(profile);
+    }
+
+    @Override
+    @Transactional
+    public void reactivate(UUID userId) {
+        log.info("Iniciando reativação do perfil para userId: {}", userId);
+
+        Profile profile = profileRepositoryPort.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("Perfil não encontrado"));
+
+        if (!profile.isDeactivated()) {
+            log.warn("Tentativa de reativar perfil já ativo: {}", userId);
+            throw new DomainException("Perfil já está ativo.");
+        }
+
+        profile.setDeactivated(false);
+        profile.setDeactivationScheduledAt(null);
+
+        profileRepositoryPort.save(profile);
+        log.info("Perfil reativado com sucesso: {}", userId);
+    }
+
+    @Override
+    @Transactional
+    public void hardDeleteExpiredProfiles() {
+        log.info("Iniciando task de exclusão permanente de perfis expirados");
+
+        OffsetDateTime currentTime = OffsetDateTime.now();
+        var expiredProfiles = profileRepositoryPort.findExpiredDeactivatedProfiles(currentTime);
+
+        if (expiredProfiles.isEmpty()) {
+            log.info("Nenhum perfil expirado para remover");
+            return;
+        }
+
+        log.info("Encontrados {} perfis expirados para exclusão permanente", expiredProfiles.size());
+
+        int deletedCount = 0;
+        List<UUID> failedIds = new ArrayList<>();
+
+        for (Profile profile : expiredProfiles) {
+            UUID userId = profile.getUserId();
+            log.info("Processando exclusão do perfil: {} ({})", userId, profile.getEmail());
+
+            boolean keycloakDeletionSuccessful = keycloakUserPort.deleteUser(userId);
+
+            if (keycloakDeletionSuccessful) {
+                try {
+                    profileRepositoryPort.delete(userId);
+                    deletedCount++;
+                    log.info("Perfil {} excluído permanentemente com sucesso", userId);
+                } catch (Exception e) {
+                    log.error("Falha ao excluir perfil local {}: {}", userId, e.getMessage(), e);
+                    failedIds.add(userId);
+                }
+            } else {
+                log.error("Falha ao excluir usuário {} do Keycloak", userId);
+                failedIds.add(userId);
+            }
+        }
+
+        String summary = String.format("Removidos %d perfis expirados.", deletedCount);
+        if (!failedIds.isEmpty()) {
+            summary += String.format(" Falha ao remover perfis: %s.", failedIds);
+        }
+
+        log.info("Task de exclusão finalizado. {}", summary);
+    }
+
+    private void publishDeletionScheduledEvent(Profile profile) {
+        ProfileNotificationData payload = ProfileNotificationData.builder()
+                .deletionScheduledAt(profile.getDeactivationScheduledAt())
+                .reactivateAccountDeepLink(REACTIVATE_ACCOUNT_DEEP_LINK)
+                .build();
+
+        PoupeAiEvent<ProfileNotificationData> event = PoupeAiEvent.<ProfileNotificationData>builder()
+                .messageId(UUID.randomUUID())
+                .timestamp(OffsetDateTime.now())
+                .triggerType("USER_ACTION")
+                .eventType("PROFILE_DELETION_SCHEDULED")
+                .recipient(PoupeAiEvent.Recipient.builder()
+                        .userId(profile.getUserId().toString())
+                        .email(profile.getEmail())
+                        .name(buildUserName(profile))
+                        .build())
+                .payload(payload)
+                .build();
+
+        profileNotificationProducerPort.publishDeletionScheduled(event);
+        log.info("Evento PROFILE_DELETION_SCHEDULED publicado para userId: {}", profile.getUserId());
+    }
+
+    private String buildUserName(Profile profile) {
+        StringBuilder name = new StringBuilder();
+        if (profile.getFirstName() != null) {
+            name.append(profile.getFirstName());
+        }
+        if (profile.getLastName() != null) {
+            if (!name.isEmpty()) {
+                name.append(" ");
+            }
+            name.append(profile.getLastName());
+        }
+        return name.toString().trim();
+    }
+}

--- a/src/main/java/io/github/poupeai/core/domain/model/Profile.java
+++ b/src/main/java/io/github/poupeai/core/domain/model/Profile.java
@@ -17,7 +17,7 @@ public class Profile {
     private String email;
     private String firstName;
     private String lastName;
-    private boolean isDeactivated;
+    private boolean deactivated;
     private OffsetDateTime deactivationScheduledAt;
     private OffsetDateTime createdAt;
     private OffsetDateTime updatedAt;

--- a/src/main/java/io/github/poupeai/core/domain/model/ProfileNotificationData.java
+++ b/src/main/java/io/github/poupeai/core/domain/model/ProfileNotificationData.java
@@ -1,0 +1,17 @@
+package io.github.poupeai.core.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProfileNotificationData {
+    private OffsetDateTime deletionScheduledAt;
+    private String reactivateAccountDeepLink;
+}

--- a/src/main/java/io/github/poupeai/core/domain/port/business/ProfileServicePort.java
+++ b/src/main/java/io/github/poupeai/core/domain/port/business/ProfileServicePort.java
@@ -1,0 +1,11 @@
+package io.github.poupeai.core.domain.port.business;
+
+import java.util.UUID;
+
+public interface ProfileServicePort {
+    void deactivate(UUID userId);
+
+    void reactivate(UUID userId);
+
+    void hardDeleteExpiredProfiles();
+}

--- a/src/main/java/io/github/poupeai/core/domain/port/external/KeycloakUserPort.java
+++ b/src/main/java/io/github/poupeai/core/domain/port/external/KeycloakUserPort.java
@@ -1,0 +1,7 @@
+package io.github.poupeai.core.domain.port.external;
+
+import java.util.UUID;
+
+public interface KeycloakUserPort {
+    boolean deleteUser(UUID userId);
+}

--- a/src/main/java/io/github/poupeai/core/domain/port/messaging/ProfileNotificationProducerPort.java
+++ b/src/main/java/io/github/poupeai/core/domain/port/messaging/ProfileNotificationProducerPort.java
@@ -1,0 +1,7 @@
+package io.github.poupeai.core.domain.port.messaging;
+
+import io.github.poupeai.core.domain.event.PoupeAiEvent;
+
+public interface ProfileNotificationProducerPort {
+    void publishDeletionScheduled(PoupeAiEvent<?> event);
+}

--- a/src/main/java/io/github/poupeai/core/domain/port/persistence/ProfileRepositoryPort.java
+++ b/src/main/java/io/github/poupeai/core/domain/port/persistence/ProfileRepositoryPort.java
@@ -2,11 +2,19 @@ package io.github.poupeai.core.domain.port.persistence;
 
 import io.github.poupeai.core.domain.model.Profile;
 
+import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface ProfileRepositoryPort {
     Profile save(Profile profile);
+
     Optional<Profile> findById(UUID id);
+
     Optional<Profile> findByEmail(String email);
+
+    List<Profile> findExpiredDeactivatedProfiles(OffsetDateTime currentTime);
+
+    void delete(UUID userId);
 }

--- a/src/main/java/io/github/poupeai/core/persistence/adapter/KeycloakUserAdapter.java
+++ b/src/main/java/io/github/poupeai/core/persistence/adapter/KeycloakUserAdapter.java
@@ -1,0 +1,41 @@
+package io.github.poupeai.core.persistence.adapter;
+
+import io.github.poupeai.core.domain.port.external.KeycloakUserPort;
+import jakarta.ws.rs.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.resource.UsersResource;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KeycloakUserAdapter implements KeycloakUserPort {
+    private final Keycloak keycloakAdminClient;
+
+    @Value("${keycloak.admin.realm}")
+    private String realm;
+
+    @Override
+    public boolean deleteUser(UUID userId) {
+        String userIdStr = userId.toString();
+        log.info("Tentando deletar usuário no Keycloak: {}", userIdStr);
+
+        try {
+            UsersResource usersResource = keycloakAdminClient.realm(realm).users();
+            usersResource.delete(userIdStr);
+            log.info("Usuário {} deletado com sucesso do Keycloak", userIdStr);
+            return true;
+        } catch (NotFoundException e) {
+            log.warn("Usuário {} não encontrado no Keycloak, considerando como já deletado", userIdStr);
+            return true;
+        } catch (Exception e) {
+            log.error("Erro ao deletar usuário {} do Keycloak: {}", userIdStr, e.getMessage(), e);
+            return false;
+        }
+    }
+}

--- a/src/main/java/io/github/poupeai/core/persistence/adapter/ProfileNotificationProducerAdapter.java
+++ b/src/main/java/io/github/poupeai/core/persistence/adapter/ProfileNotificationProducerAdapter.java
@@ -1,0 +1,29 @@
+package io.github.poupeai.core.persistence.adapter;
+
+import io.github.poupeai.core.domain.event.PoupeAiEvent;
+import io.github.poupeai.core.domain.port.messaging.ProfileNotificationProducerPort;
+import io.github.poupeai.core.persistence.messaging.RabbitMQPublisher;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ProfileNotificationProducerAdapter implements ProfileNotificationProducerPort {
+    private final RabbitMQPublisher rabbitMQPublisher;
+
+    @Value("${app.rabbitmq.notifications.exchange}")
+    private String exchange;
+
+    @Value("${app.rabbitmq.notifications.routing-key}")
+    private String routingKey;
+
+    @Override
+    public void publishDeletionScheduled(PoupeAiEvent<?> event) {
+        log.info("Publicando evento PROFILE_DELETION_SCHEDULED para usuário: {}",
+                event.getRecipient() != null ? event.getRecipient().getUserId() : "N/A");
+        rabbitMQPublisher.publish(exchange, routingKey, event);
+    }
+}

--- a/src/main/java/io/github/poupeai/core/persistence/adapter/ProfileRepositoryAdapter.java
+++ b/src/main/java/io/github/poupeai/core/persistence/adapter/ProfileRepositoryAdapter.java
@@ -7,6 +7,8 @@ import io.github.poupeai.core.persistence.repository.ProfileRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -31,5 +33,18 @@ public class ProfileRepositoryAdapter implements ProfileRepositoryPort {
     @Override
     public Optional<Profile> findByEmail(String email) {
         return repository.findByEmail(email).map(mapper::toDomain);
+    }
+
+    @Override
+    public List<Profile> findExpiredDeactivatedProfiles(OffsetDateTime currentTime) {
+        return repository.findExpiredDeactivatedProfiles(currentTime)
+                .stream()
+                .map(mapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public void delete(UUID userId) {
+        repository.deleteById(userId);
     }
 }

--- a/src/main/java/io/github/poupeai/core/persistence/config/KeycloakConfig.java
+++ b/src/main/java/io/github/poupeai/core/persistence/config/KeycloakConfig.java
@@ -1,0 +1,39 @@
+package io.github.poupeai.core.persistence.config;
+
+import org.keycloak.OAuth2Constants;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.KeycloakBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class KeycloakConfig {
+
+    @Value("${keycloak.admin.server-url}")
+    private String serverUrl;
+
+    @Value("${keycloak.admin.realm}")
+    private String realm;
+
+    @Value("${keycloak.admin.client-id}")
+    private String clientId;
+
+    @Value("${keycloak.admin.username}")
+    private String username;
+
+    @Value("${keycloak.admin.password}")
+    private String password;
+
+    @Bean
+    public Keycloak keycloakAdminClient() {
+        return KeycloakBuilder.builder()
+                .serverUrl(serverUrl)
+                .realm("master")
+                .clientId(clientId)
+                .username(username)
+                .password(password)
+                .grantType(OAuth2Constants.PASSWORD)
+                .build();
+    }
+}

--- a/src/main/java/io/github/poupeai/core/persistence/entity/ProfileEntity.java
+++ b/src/main/java/io/github/poupeai/core/persistence/entity/ProfileEntity.java
@@ -38,7 +38,7 @@ public class ProfileEntity {
     private String lastName;
 
     @Column(name = "is_deactivated")
-    private boolean isDeactivated;
+    private boolean deactivated;
 
     @Column(name = "deactivation_scheduled_at")
     private OffsetDateTime deactivationScheduledAt;

--- a/src/main/java/io/github/poupeai/core/persistence/repository/InvoiceRepository.java
+++ b/src/main/java/io/github/poupeai/core/persistence/repository/InvoiceRepository.java
@@ -16,88 +16,88 @@ import java.util.UUID;
 
 @Repository
 public interface InvoiceRepository extends JpaRepository<InvoiceEntity, UUID>, JpaSpecificationExecutor<InvoiceEntity> {
-    Optional<InvoiceEntity> findByCreditCardIdAndMonthAndYear(UUID creditCardId, Integer month, Integer year);
+        Optional<InvoiceEntity> findByCreditCardIdAndMonthAndYear(UUID creditCardId, Integer month, Integer year);
 
-    List<InvoiceEntity> findByCreditCardId(UUID creditCardId);
+        List<InvoiceEntity> findByCreditCardId(UUID creditCardId);
 
-    List<InvoiceEntity> findByCreditCardProfileUserId(UUID profileId);
+        List<InvoiceEntity> findByCreditCardProfileUserId(UUID profileId);
 
-    Optional<InvoiceEntity> findByIdAndCreditCardProfileUserId(UUID id, UUID profileId);
+        Optional<InvoiceEntity> findByIdAndCreditCardProfileUserId(UUID id, UUID profileId);
 
-    boolean existsByCreditCardIdAndMonthAndYear(UUID creditCardId, Integer month, Integer year);
+        boolean existsByCreditCardIdAndMonthAndYear(UUID creditCardId, Integer month, Integer year);
 
-    @Query("""
-        SELECT COALESCE(SUM(i.totalAmount - i.paidAmount), 0)
-        FROM InvoiceEntity i
-        WHERE i.creditCard.id = :creditCardId
-        AND i.status IN ('OPEN', 'CLOSED', 'OVERDUE')
-        """)
-    BigDecimal calculateUsedCreditLimit(@Param("creditCardId") UUID creditCardId);
+        @Query("""
+                        SELECT COALESCE(SUM(i.totalAmount - i.paidAmount), 0)
+                        FROM InvoiceEntity i
+                        WHERE i.creditCard.id = :creditCardId
+                        AND i.status IN ('OPEN', 'CLOSED', 'OVERDUE')
+                        """)
+        BigDecimal calculateUsedCreditLimit(@Param("creditCardId") UUID creditCardId);
 
-    @Query("""
-            SELECT i FROM InvoiceEntity i
-            JOIN FETCH i.creditCard cc
-            JOIN FETCH cc.profile p
-            WHERE i.dueDate BETWEEN :startDate AND :endDate
-            AND (i.status = 'OPEN' OR i.status = 'CLOSED')
-            AND COALESCE(i.dueSoonNotificationSent, false) = false
-            """)
-    List<InvoiceEntity> findDueSoonNotNotified(
-            @Param("startDate") LocalDate startDate,
-            @Param("endDate") LocalDate endDate);
+        @Query("""
+                        SELECT i FROM InvoiceEntity i
+                        JOIN FETCH i.creditCard cc
+                        JOIN FETCH cc.profile p
+                        WHERE i.dueDate BETWEEN :startDate AND :endDate
+                        AND (i.status = 'OPEN' OR i.status = 'CLOSED')
+                        AND COALESCE(i.dueSoonNotificationSent, false) = false
+                        """)
+        List<InvoiceEntity> findDueSoonNotNotified(
+                        @Param("startDate") LocalDate startDate,
+                        @Param("endDate") LocalDate endDate);
 
-    @Query("""
-            SELECT i FROM InvoiceEntity i
-            JOIN FETCH i.creditCard cc
-            JOIN FETCH cc.profile p
-            WHERE i.dueDate < :today
-            AND (i.status = 'OPEN' OR i.status = 'CLOSED')
-            AND COALESCE(i.overdueNotificationSent, false) = false
-            AND i.paidAmount < i.totalAmount
-            """)
-    List<InvoiceEntity> findOverdueNotNotified(
-            @Param("today") LocalDate today);
+        @Query("""
+                        SELECT i FROM InvoiceEntity i
+                        JOIN FETCH i.creditCard cc
+                        JOIN FETCH cc.profile p
+                        WHERE i.dueDate < :today
+                        AND (i.status = 'OPEN' OR i.status = 'CLOSED')
+                        AND COALESCE(i.overdueNotificationSent, false) = false
+                        AND i.paidAmount < i.totalAmount
+                        """)
+        List<InvoiceEntity> findOverdueNotNotified(
+                        @Param("today") LocalDate today);
 
-    @Query("""
-            SELECT new io.github.poupeai.core.domain.model.InvoiceNotificationData(
-                i.id, cc.id, cc.name, i.month, i.year, i.dueDate, i.totalAmount, i.paidAmount,
-                p.userId, p.email, CONCAT(p.firstName, ' ', p.lastName)
-            )
-            FROM InvoiceEntity i
-            JOIN i.creditCard cc
-            JOIN cc.profile p
-            WHERE i.dueDate BETWEEN :startDate AND :endDate
-            AND (i.status = 'OPEN' OR i.status = 'CLOSED')
-            AND COALESCE(i.dueSoonNotificationSent, false) = false
-            AND p.isDeactivated = false
-            """)
-    List<InvoiceNotificationData> findDueSoonNotificationsData(
-            @Param("startDate") LocalDate startDate,
-            @Param("endDate") LocalDate endDate);
+        @Query("""
+                        SELECT new io.github.poupeai.core.domain.model.InvoiceNotificationData(
+                            i.id, cc.id, cc.name, i.month, i.year, i.dueDate, i.totalAmount, i.paidAmount,
+                            p.userId, p.email, CONCAT(p.firstName, ' ', p.lastName)
+                        )
+                        FROM InvoiceEntity i
+                        JOIN i.creditCard cc
+                        JOIN cc.profile p
+                        WHERE i.dueDate BETWEEN :startDate AND :endDate
+                        AND (i.status = 'OPEN' OR i.status = 'CLOSED')
+                        AND COALESCE(i.dueSoonNotificationSent, false) = false
+                        AND p.deactivated = false
+                        """)
+        List<InvoiceNotificationData> findDueSoonNotificationsData(
+                        @Param("startDate") LocalDate startDate,
+                        @Param("endDate") LocalDate endDate);
 
-    @Query("""
-            SELECT new io.github.poupeai.core.domain.model.InvoiceNotificationData(
-                i.id, cc.id, cc.name, i.month, i.year, i.dueDate, i.totalAmount, i.paidAmount,
-                p.userId, p.email, CONCAT(p.firstName, ' ', p.lastName)
-            )
-            FROM InvoiceEntity i
-            JOIN i.creditCard cc
-            JOIN cc.profile p
-            WHERE i.dueDate < :today
-            AND (i.status = 'OPEN' OR i.status = 'CLOSED')
-            AND COALESCE(i.overdueNotificationSent, false) = false
-            AND i.paidAmount < i.totalAmount
-            AND p.isDeactivated = false
-            """)
-    List<InvoiceNotificationData> findOverdueNotificationsData(
-            @Param("today") LocalDate today);
+        @Query("""
+                        SELECT new io.github.poupeai.core.domain.model.InvoiceNotificationData(
+                            i.id, cc.id, cc.name, i.month, i.year, i.dueDate, i.totalAmount, i.paidAmount,
+                            p.userId, p.email, CONCAT(p.firstName, ' ', p.lastName)
+                        )
+                        FROM InvoiceEntity i
+                        JOIN i.creditCard cc
+                        JOIN cc.profile p
+                        WHERE i.dueDate < :today
+                        AND (i.status = 'OPEN' OR i.status = 'CLOSED')
+                        AND COALESCE(i.overdueNotificationSent, false) = false
+                        AND i.paidAmount < i.totalAmount
+                        AND p.deactivated = false
+                        """)
+        List<InvoiceNotificationData> findOverdueNotificationsData(
+                        @Param("today") LocalDate today);
 
-    @Query("SELECT i FROM InvoiceEntity i " +
-            "JOIN i.creditCard cc " +
-            "WHERE cc.profile.userId = :profileId " +
-            "AND i.month = :month AND i.year = :year")
-    List<InvoiceEntity> findByProfileIdAndMonthAndYear(
-            @Param("profileId") UUID profileId,
-            @Param("month") Integer month,
-            @Param("year") Integer year);
+        @Query("SELECT i FROM InvoiceEntity i " +
+                        "JOIN i.creditCard cc " +
+                        "WHERE cc.profile.userId = :profileId " +
+                        "AND i.month = :month AND i.year = :year")
+        List<InvoiceEntity> findByProfileIdAndMonthAndYear(
+                        @Param("profileId") UUID profileId,
+                        @Param("month") Integer month,
+                        @Param("year") Integer year);
 }

--- a/src/main/java/io/github/poupeai/core/persistence/repository/ProfileRepository.java
+++ b/src/main/java/io/github/poupeai/core/persistence/repository/ProfileRepository.java
@@ -2,10 +2,17 @@ package io.github.poupeai.core.persistence.repository;
 
 import io.github.poupeai.core.persistence.entity.ProfileEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface ProfileRepository extends JpaRepository<ProfileEntity, UUID> {
     Optional<ProfileEntity> findByEmail(String email);
+
+    @Query("SELECT p FROM ProfileEntity p WHERE p.deactivated = true AND p.deactivationScheduledAt <= :currentTime")
+    List<ProfileEntity> findExpiredDeactivatedProfiles(@Param("currentTime") OffsetDateTime currentTime);
 }

--- a/src/main/java/io/github/poupeai/core/web/controller/profile/ProfileController.java
+++ b/src/main/java/io/github/poupeai/core/web/controller/profile/ProfileController.java
@@ -2,6 +2,7 @@ package io.github.poupeai.core.web.controller.profile;
 
 import io.github.poupeai.core.domain.model.Profile;
 import io.github.poupeai.core.domain.port.business.GetProfilePort;
+import io.github.poupeai.core.domain.port.business.ProfileServicePort;
 import io.github.poupeai.core.web.dto.profile.ProfileResponse;
 import io.github.poupeai.core.web.mapper.profile.ProfileControllerMapper;
 import io.github.poupeai.core.web.security.CurrentUserId;
@@ -13,9 +14,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Map;
 import java.util.UUID;
 
 @Slf4j
@@ -25,17 +28,13 @@ import java.util.UUID;
 @Tag(name = "Profiles", description = "Gerenciamento de Perfis de Usuário")
 public class ProfileController {
     private final GetProfilePort getProfilePort;
+    private final ProfileServicePort profileServicePort;
     private final ProfileControllerMapper mapper;
 
     @GetMapping
-    @Operation(
-            summary = "Obter Meu Perfil",
-            description = "Retorna os dados do usuário logado com base no Token JWT.",
-            security = @SecurityRequirement(name = "bearer-key")
-    )
+    @Operation(summary = "Obter Meu Perfil", description = "Retorna os dados do usuário logado com base no Token JWT.", security = @SecurityRequirement(name = "bearer-key"))
     public ResponseEntity<ProfileResponse> getMyProfile(
-            @Parameter(hidden = true) @CurrentUserId String userId
-    ) {
+            @Parameter(hidden = true) @CurrentUserId String userId) {
         log.info("Buscando perfil para o usuário autenticado: {}", userId);
 
         UUID uuid = UUID.fromString(userId);
@@ -43,5 +42,31 @@ public class ProfileController {
         Profile profile = getProfilePort.execute(uuid);
 
         return ResponseEntity.ok(mapper.toResponse(profile));
+    }
+
+    @PatchMapping("/deactivate")
+    @Operation(summary = "Desativar Conta", description = "Desativa a conta do usuário autenticado e agenda exclusão permanente.", security = @SecurityRequirement(name = "bearer-key"))
+    public ResponseEntity<Map<String, String>> deactivateProfile(
+            @Parameter(hidden = true) @CurrentUserId String userId) {
+        log.info("Desativando perfil para o usuário: {}", userId);
+
+        UUID uuid = UUID.fromString(userId);
+        profileServicePort.deactivate(uuid);
+
+        return ResponseEntity.ok(Map.of(
+                "detail", "Perfil desativado com sucesso. Exclusão permanente agendada."));
+    }
+
+    @PatchMapping("/reactivate")
+    @Operation(summary = "Reativar Conta", description = "Reativa uma conta previamente desativada e cancela a exclusão agendada.", security = @SecurityRequirement(name = "bearer-key"))
+    public ResponseEntity<Map<String, String>> reactivateProfile(
+            @Parameter(hidden = true) @CurrentUserId String userId) {
+        log.info("Reativando perfil para o usuário: {}", userId);
+
+        UUID uuid = UUID.fromString(userId);
+        profileServicePort.reactivate(uuid);
+
+        return ResponseEntity.ok(Map.of(
+                "detail", "Perfil reativado com sucesso. Exclusão agendada foi cancelada."));
     }
 }

--- a/src/main/java/io/github/poupeai/core/web/dto/profile/ProfileResponse.java
+++ b/src/main/java/io/github/poupeai/core/web/dto/profile/ProfileResponse.java
@@ -16,5 +16,5 @@ public class ProfileResponse {
     private String email;
     private String firstName;
     private String lastName;
-    private boolean isDeactivated;
+    private boolean deactivated;
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,6 +26,14 @@ spring.flyway.baseline-on-migrate=true
 spring.security.oauth2.resourceserver.jwt.issuer-uri=${KEYCLOAK_ISSUER}
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${KEYCLOAK_JWKS_URL}
 
+# Keycloak Admin Client Configuration
+keycloak.admin.server-url=${KEYCLOAK_SERVER_URL}
+keycloak.admin.realm=${KEYCLOAK_REALM:poupe-ai}
+keycloak.admin.client-id=${KEYCLOAK_ADMIN_CLIENT_ID:admin-cli}
+keycloak.admin.client-secret=${KEYCLOAK_ADMIN_CLIENT_SECRET}
+keycloak.admin.username=${KEYCLOAK_ADMIN_USER}
+keycloak.admin.password=${KEYCLOAK_ADMIN_PASSWORD}
+
 # MinIO Configuration
 minio.endpoint=${MINIO_ENDPOINT:http://localhost:9000}
 minio.access-key=${MINIO_ACCESS_KEY:minioadmin}
@@ -56,3 +64,7 @@ app.rabbitmq.notifications.routing-key=${RABBITMQ_NOTIFICATIONS_ROUTING_KEY:noti
 app.scheduler.invoice.due-soon-days=${INVOICE_DUE_SOON_DAYS:5}
 app.scheduler.invoice.due-soon-cron=${INVOICE_DUE_SOON_CRON:0 0 9 * * *}
 app.scheduler.invoice.overdue-cron=${INVOICE_OVERDUE_CRON:0 5 9 * * *}
+
+# Profile Deletion Scheduler Configuration
+app.scheduler.profile.deletion-cron=${PROFILE_DELETION_CRON:0 59 23 * * *}
+

--- a/src/main/resources/db/migration/V14__add_cascade_delete_to_profile_relations.sql
+++ b/src/main/resources/db/migration/V14__add_cascade_delete_to_profile_relations.sql
@@ -1,0 +1,29 @@
+ALTER TABLE categories
+    DROP CONSTRAINT fk_category_profile,
+    ADD CONSTRAINT fk_category_profile FOREIGN KEY (profile_id) 
+        REFERENCES profiles(user_id) ON DELETE CASCADE;
+
+ALTER TABLE goals
+    DROP CONSTRAINT fk_goal_profile,
+    ADD CONSTRAINT fk_goal_profile FOREIGN KEY (profile_id) 
+        REFERENCES profiles(user_id) ON DELETE CASCADE;
+
+ALTER TABLE credit_cards
+    DROP CONSTRAINT fk_credit_card_profile,
+    ADD CONSTRAINT fk_credit_card_profile FOREIGN KEY (profile_id) 
+        REFERENCES profiles(user_id) ON DELETE CASCADE;
+
+ALTER TABLE bank_accounts
+    DROP CONSTRAINT fk_bank_account_profile,
+    ADD CONSTRAINT fk_bank_account_profile FOREIGN KEY (profile_id) 
+        REFERENCES profiles(user_id) ON DELETE CASCADE;
+
+ALTER TABLE transactions
+    DROP CONSTRAINT fk_transaction_profile,
+    ADD CONSTRAINT fk_transaction_profile FOREIGN KEY (profile_id) 
+        REFERENCES profiles(user_id) ON DELETE CASCADE;
+
+ALTER TABLE ingestion_jobs
+    DROP CONSTRAINT fk_ingestion_jobs_profiles,
+    ADD CONSTRAINT fk_ingestion_jobs_profiles FOREIGN KEY (profile_id) 
+        REFERENCES profiles(user_id) ON DELETE CASCADE;

--- a/src/test/java/io/github/poupeai/core/application/scheduler/ProfileDeletionSchedulerTest.java
+++ b/src/test/java/io/github/poupeai/core/application/scheduler/ProfileDeletionSchedulerTest.java
@@ -1,0 +1,39 @@
+package io.github.poupeai.core.application.scheduler;
+
+import io.github.poupeai.core.domain.port.business.ProfileServicePort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileDeletionSchedulerTest {
+
+    @Mock
+    private ProfileServicePort profileServicePort;
+
+    @InjectMocks
+    private ProfileDeletionScheduler profileDeletionScheduler;
+
+    @Test
+    @DisplayName("Should call hardDeleteExpiredProfiles from service port")
+    void shouldCallHardDeleteExpiredProfiles() {
+        profileDeletionScheduler.processExpiredProfiles();
+
+        verify(profileServicePort, times(1)).hardDeleteExpiredProfiles();
+    }
+
+    @Test
+    @DisplayName("Should handle exceptions gracefully without rethrowing")
+    void shouldHandleExceptionsGracefully() {
+        doThrow(new RuntimeException("Test exception")).when(profileServicePort).hardDeleteExpiredProfiles();
+
+        profileDeletionScheduler.processExpiredProfiles();
+
+        verify(profileServicePort, times(1)).hardDeleteExpiredProfiles();
+    }
+}

--- a/src/test/java/io/github/poupeai/core/audit/ProfileAuditListenerTest.java
+++ b/src/test/java/io/github/poupeai/core/audit/ProfileAuditListenerTest.java
@@ -112,7 +112,7 @@ class ProfileAuditListenerTest {
                 .email("old@example.com")
                 .firstName("OldFirst")
                 .lastName("OldLast")
-                .isDeactivated(false)
+                .deactivated(false)
                 .build();
 
         listener.postLoad(entity);
@@ -165,7 +165,6 @@ class ProfileAuditListenerTest {
 
         listener.postLoad(entity);
 
-
         listener.postUpdate(entity);
 
         verify(applicationContext, never()).publishEvent(any());
@@ -177,7 +176,7 @@ class ProfileAuditListenerTest {
                 .email("test@example.com")
                 .firstName("Test")
                 .lastName("User")
-                .isDeactivated(false)
+                .deactivated(false)
                 .build();
     }
 }

--- a/src/test/java/io/github/poupeai/core/business/adapter/ProfileServiceAdapterTest.java
+++ b/src/test/java/io/github/poupeai/core/business/adapter/ProfileServiceAdapterTest.java
@@ -1,0 +1,251 @@
+package io.github.poupeai.core.business.adapter;
+
+import io.github.poupeai.core.domain.event.PoupeAiEvent;
+import io.github.poupeai.core.domain.exception.DomainException;
+import io.github.poupeai.core.domain.exception.ResourceNotFoundException;
+import io.github.poupeai.core.domain.model.Profile;
+import io.github.poupeai.core.domain.port.external.KeycloakUserPort;
+import io.github.poupeai.core.domain.port.messaging.ProfileNotificationProducerPort;
+import io.github.poupeai.core.domain.port.persistence.ProfileRepositoryPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileServiceAdapterTest {
+
+    @Mock
+    private ProfileRepositoryPort profileRepositoryPort;
+
+    @Mock
+    private ProfileNotificationProducerPort profileNotificationProducerPort;
+
+    @Mock
+    private KeycloakUserPort keycloakUserPort;
+
+    @InjectMocks
+    private ProfileServiceAdapter profileServiceAdapter;
+
+    @Captor
+    private ArgumentCaptor<Profile> profileCaptor;
+
+    @Captor
+    private ArgumentCaptor<PoupeAiEvent<?>> eventCaptor;
+
+    @Nested
+    @DisplayName("deactivate()")
+    class DeactivateTests {
+
+        @Test
+        @DisplayName("Should deactivate profile and publish event when profile is active")
+        void shouldDeactivateProfileAndPublishEvent() {
+            UUID userId = UUID.randomUUID();
+            Profile activeProfile = Profile.builder()
+                    .userId(userId)
+                    .email("test@example.com")
+                    .firstName("John")
+                    .lastName("Doe")
+                    .deactivated(false)
+                    .build();
+
+            when(profileRepositoryPort.findById(userId)).thenReturn(Optional.of(activeProfile));
+            when(profileRepositoryPort.save(any(Profile.class))).thenAnswer(i -> i.getArgument(0));
+
+            profileServiceAdapter.deactivate(userId);
+
+            verify(profileRepositoryPort).save(profileCaptor.capture());
+            Profile savedProfile = profileCaptor.getValue();
+
+            assertTrue(savedProfile.isDeactivated());
+            assertNotNull(savedProfile.getDeactivationScheduledAt());
+
+            verify(profileNotificationProducerPort).publishDeletionScheduled(eventCaptor.capture());
+            PoupeAiEvent<?> event = eventCaptor.getValue();
+
+            assertEquals("PROFILE_DELETION_SCHEDULED", event.getEventType());
+            assertEquals("USER_ACTION", event.getTriggerType());
+            assertEquals(userId.toString(), event.getRecipient().getUserId());
+            assertEquals("test@example.com", event.getRecipient().getEmail());
+            assertEquals("John Doe", event.getRecipient().getName());
+        }
+
+        @Test
+        @DisplayName("Should throw DomainException when profile is already deactivated")
+        void shouldThrowExceptionWhenAlreadyDeactivated() {
+            UUID userId = UUID.randomUUID();
+            Profile deactivatedProfile = Profile.builder()
+                    .userId(userId)
+                    .deactivated(true)
+                    .build();
+
+            when(profileRepositoryPort.findById(userId)).thenReturn(Optional.of(deactivatedProfile));
+
+            assertThrows(DomainException.class, () -> profileServiceAdapter.deactivate(userId));
+
+            verify(profileRepositoryPort, never()).save(any());
+            verify(profileNotificationProducerPort, never()).publishDeletionScheduled(any());
+        }
+
+        @Test
+        @DisplayName("Should throw ResourceNotFoundException when profile does not exist")
+        void shouldThrowExceptionWhenProfileNotFound() {
+            UUID userId = UUID.randomUUID();
+            when(profileRepositoryPort.findById(userId)).thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class, () -> profileServiceAdapter.deactivate(userId));
+
+            verify(profileRepositoryPort, never()).save(any());
+            verify(profileNotificationProducerPort, never()).publishDeletionScheduled(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("reactivate()")
+    class ReactivateTests {
+
+        @Test
+        @DisplayName("Should reactivate profile and clear flags when profile is deactivated")
+        void shouldReactivateProfileAndClearFlags() {
+            UUID userId = UUID.randomUUID();
+            Profile deactivatedProfile = Profile.builder()
+                    .userId(userId)
+                    .deactivated(true)
+                    .deactivationScheduledAt(OffsetDateTime.now().plusDays(30))
+                    .build();
+
+            when(profileRepositoryPort.findById(userId)).thenReturn(Optional.of(deactivatedProfile));
+            when(profileRepositoryPort.save(any(Profile.class))).thenAnswer(i -> i.getArgument(0));
+
+            profileServiceAdapter.reactivate(userId);
+
+            verify(profileRepositoryPort).save(profileCaptor.capture());
+            Profile savedProfile = profileCaptor.getValue();
+
+            assertFalse(savedProfile.isDeactivated());
+            assertNull(savedProfile.getDeactivationScheduledAt());
+        }
+
+        @Test
+        @DisplayName("Should throw DomainException when profile is already active")
+        void shouldThrowExceptionWhenAlreadyActive() {
+            UUID userId = UUID.randomUUID();
+            Profile activeProfile = Profile.builder()
+                    .userId(userId)
+                    .deactivated(false)
+                    .build();
+
+            when(profileRepositoryPort.findById(userId)).thenReturn(Optional.of(activeProfile));
+
+            assertThrows(DomainException.class, () -> profileServiceAdapter.reactivate(userId));
+
+            verify(profileRepositoryPort, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("Should throw ResourceNotFoundException when profile does not exist")
+        void shouldThrowExceptionWhenProfileNotFound() {
+            UUID userId = UUID.randomUUID();
+            when(profileRepositoryPort.findById(userId)).thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class, () -> profileServiceAdapter.reactivate(userId));
+
+            verify(profileRepositoryPort, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("hardDeleteExpiredProfiles()")
+    class HardDeleteTests {
+
+        @Test
+        @DisplayName("Should delete from Keycloak and local when both succeed")
+        void shouldDeleteAllExpiredProfiles() {
+            UUID userId1 = UUID.randomUUID();
+            UUID userId2 = UUID.randomUUID();
+
+            List<Profile> expiredProfiles = List.of(
+                    Profile.builder().userId(userId1).email("user1@example.com").build(),
+                    Profile.builder().userId(userId2).email("user2@example.com").build());
+
+            when(profileRepositoryPort.findExpiredDeactivatedProfiles(any(OffsetDateTime.class)))
+                    .thenReturn(expiredProfiles);
+            when(keycloakUserPort.deleteUser(any(UUID.class))).thenReturn(true);
+
+            profileServiceAdapter.hardDeleteExpiredProfiles();
+
+            verify(keycloakUserPort).deleteUser(userId1);
+            verify(keycloakUserPort).deleteUser(userId2);
+            verify(profileRepositoryPort).delete(userId1);
+            verify(profileRepositoryPort).delete(userId2);
+        }
+
+        @Test
+        @DisplayName("Should handle empty list of expired profiles")
+        void shouldHandleEmptyList() {
+            when(profileRepositoryPort.findExpiredDeactivatedProfiles(any(OffsetDateTime.class)))
+                    .thenReturn(List.of());
+
+            profileServiceAdapter.hardDeleteExpiredProfiles();
+
+            verify(keycloakUserPort, never()).deleteUser(any());
+            verify(profileRepositoryPort, never()).delete(any());
+        }
+
+        @Test
+        @DisplayName("Should not delete local profile when Keycloak deletion fails")
+        void shouldNotDeleteLocalWhenKeycloakFails() {
+            UUID userId1 = UUID.randomUUID();
+            UUID userId2 = UUID.randomUUID();
+
+            List<Profile> expiredProfiles = List.of(
+                    Profile.builder().userId(userId1).email("user1@example.com").build(),
+                    Profile.builder().userId(userId2).email("user2@example.com").build());
+
+            when(profileRepositoryPort.findExpiredDeactivatedProfiles(any(OffsetDateTime.class)))
+                    .thenReturn(expiredProfiles);
+            when(keycloakUserPort.deleteUser(userId1)).thenReturn(false);
+            when(keycloakUserPort.deleteUser(userId2)).thenReturn(true);
+
+            assertDoesNotThrow(() -> profileServiceAdapter.hardDeleteExpiredProfiles());
+
+            verify(profileRepositoryPort, never()).delete(userId1);
+            verify(profileRepositoryPort).delete(userId2);
+        }
+
+        @Test
+        @DisplayName("Should continue processing when local deletion fails")
+        void shouldContinueOnLocalDeletionError() {
+            UUID userId1 = UUID.randomUUID();
+            UUID userId2 = UUID.randomUUID();
+
+            List<Profile> expiredProfiles = List.of(
+                    Profile.builder().userId(userId1).email("user1@example.com").build(),
+                    Profile.builder().userId(userId2).email("user2@example.com").build());
+
+            when(profileRepositoryPort.findExpiredDeactivatedProfiles(any(OffsetDateTime.class)))
+                    .thenReturn(expiredProfiles);
+            when(keycloakUserPort.deleteUser(any(UUID.class))).thenReturn(true);
+            doThrow(new RuntimeException("DB Error")).when(profileRepositoryPort).delete(userId1);
+
+            assertDoesNotThrow(() -> profileServiceAdapter.hardDeleteExpiredProfiles());
+
+            verify(profileRepositoryPort).delete(userId1);
+            verify(profileRepositoryPort).delete(userId2);
+        }
+    }
+}

--- a/src/test/java/io/github/poupeai/core/web/controller/profile/ProfileControllerTest.java
+++ b/src/test/java/io/github/poupeai/core/web/controller/profile/ProfileControllerTest.java
@@ -1,11 +1,14 @@
 package io.github.poupeai.core.web.controller.profile;
 
+import io.github.poupeai.core.domain.exception.DomainException;
 import io.github.poupeai.core.domain.exception.ResourceNotFoundException;
 import io.github.poupeai.core.domain.model.Profile;
 import io.github.poupeai.core.domain.port.business.GetProfilePort;
+import io.github.poupeai.core.domain.port.business.ProfileServicePort;
 import io.github.poupeai.core.web.mapper.profile.ProfileControllerMapper;
 import io.github.poupeai.core.web.dto.profile.ProfileResponse;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -14,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import java.util.Map;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -29,43 +33,127 @@ class ProfileControllerTest {
     private GetProfilePort getProfilePort;
 
     @Mock
+    private ProfileServicePort profileServicePort;
+
+    @Mock
     private ProfileControllerMapper mapper;
 
-    @Test
+    @Nested
+    @DisplayName("getMyProfile()")
+    class GetMyProfileTests {
+
+        @Test
     @DisplayName("Should successfully return the profile when the UUID is exists (Happy Path).")
-    void getMyProfileShouldReturnProfileWhenUserExists() {
-        String validUserId = "550e8400-e29b-41d4-a716-446655440000";
-        UUID uuid = UUID.fromString(validUserId);
+        void getMyProfileShouldReturnProfileWhenUserExists() {
+            String validUserId = "550e8400-e29b-41d4-a716-446655440000";
+            UUID uuid = UUID.fromString(validUserId);
 
-        Profile mockProfile = new Profile();
-        ProfileResponse mockResponse = new ProfileResponse();
+            Profile mockProfile = new Profile();
+            ProfileResponse mockResponse = new ProfileResponse();
 
-        when(getProfilePort.execute(uuid)).thenReturn(mockProfile);
-        when(mapper.toResponse(mockProfile)).thenReturn(mockResponse);
+            when(getProfilePort.execute(uuid)).thenReturn(mockProfile);
+            when(mapper.toResponse(mockProfile)).thenReturn(mockResponse);
 
-        ResponseEntity<ProfileResponse> response = profileController.getMyProfile(validUserId);
+            ResponseEntity<ProfileResponse> response = profileController.getMyProfile(validUserId);
 
-        assertNotNull(response);
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertEquals(mockResponse, response.getBody());
+            assertNotNull(response);
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertEquals(mockResponse, response.getBody());
 
-        verify(getProfilePort, times(1)).execute(uuid);
-        verify(mapper, times(1)).toResponse(mockProfile);
+            verify(getProfilePort, times(1)).execute(uuid);
+            verify(mapper, times(1)).toResponse(mockProfile);
+        }
+
+        @Test
+    @DisplayName("Should thrown ResourceNotFoundException when the profile is not found on the entry port")
+        void getMyProfileShouldThrowNotFoundWhenProfileDoesNotExist() {
+            String validUserId = "550e8400-e29b-41d4-a716-446655440000";
+            UUID uuid = UUID.fromString(validUserId);
+
+            when(getProfilePort.execute(uuid)).thenThrow(new ResourceNotFoundException("Perfil não encontrado"));
+
+            assertThrows(ResourceNotFoundException.class, () -> {
+                profileController.getMyProfile(validUserId);
+            });
+
+            verify(getProfilePort).execute(uuid);
+            verifyNoInteractions(mapper);
+        }
     }
 
-    @Test
-    @DisplayName("Should thrown ResourceNotFoundException when the profile is not found on the entry port")
-    void getMyProfileShouldThrowNotFoundWhenProfileDoesNotExist() {
-        String validUserId = "550e8400-e29b-41d4-a716-446655440000";
-        UUID uuid = UUID.fromString(validUserId);
+    @Nested
+    @DisplayName("deactivateProfile()")
+    class DeactivateProfileTests {
 
-        when(getProfilePort.execute(uuid)).thenThrow(new ResourceNotFoundException("Perfil não encontrado"));
+        @Test
+        @DisplayName("Should return 200 when deactivation is successful")
+        void shouldReturn200WhenDeactivationSuccessful() {
+            String validUserId = "550e8400-e29b-41d4-a716-446655440000";
+            UUID uuid = UUID.fromString(validUserId);
 
-        assertThrows(ResourceNotFoundException.class, () -> {
-            profileController.getMyProfile(validUserId);
-        });
+            doNothing().when(profileServicePort).deactivate(uuid);
 
-        verify(getProfilePort).execute(uuid);
-        verifyNoInteractions(mapper);
+            ResponseEntity<Map<String, String>> response = profileController.deactivateProfile(validUserId);
+
+            assertNotNull(response);
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertTrue(response.getBody().containsKey("detail"));
+
+            verify(profileServicePort, times(1)).deactivate(uuid);
+        }
+
+        @Test
+        @DisplayName("Should throw DomainException when profile is already deactivated")
+        void shouldThrowDomainExceptionWhenAlreadyDeactivated() {
+            String validUserId = "550e8400-e29b-41d4-a716-446655440000";
+            UUID uuid = UUID.fromString(validUserId);
+
+            doThrow(new DomainException("Perfil já está desativado"))
+                    .when(profileServicePort).deactivate(uuid);
+
+            assertThrows(DomainException.class, () -> {
+                profileController.deactivateProfile(validUserId);
+            });
+
+            verify(profileServicePort).deactivate(uuid);
+        }
+    }
+
+    @Nested
+    @DisplayName("reactivateProfile()")
+    class ReactivateProfileTests {
+
+        @Test
+        @DisplayName("Should return 200 when reactivation is successful")
+        void shouldReturn200WhenReactivationSuccessful() {
+            String validUserId = "550e8400-e29b-41d4-a716-446655440000";
+            UUID uuid = UUID.fromString(validUserId);
+
+            doNothing().when(profileServicePort).reactivate(uuid);
+
+            ResponseEntity<Map<String, String>> response = profileController.reactivateProfile(validUserId);
+
+            assertNotNull(response);
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertTrue(response.getBody().containsKey("detail"));
+
+            verify(profileServicePort, times(1)).reactivate(uuid);
+        }
+
+        @Test
+        @DisplayName("Should throw DomainException when profile is already active")
+        void shouldThrowDomainExceptionWhenAlreadyActive() {
+            String validUserId = "550e8400-e29b-41d4-a716-446655440000";
+            UUID uuid = UUID.fromString(validUserId);
+
+            doThrow(new DomainException("Perfil já está ativo"))
+                    .when(profileServicePort).reactivate(uuid);
+
+            assertThrows(DomainException.class, () -> {
+                profileController.reactivateProfile(validUserId);
+            });
+
+            verify(profileServicePort).reactivate(uuid);
+        }
     }
 }


### PR DESCRIPTION
## Funcionalidade de desativar/reativar perfil e agendador de limpeza de perfis

### Observações

A task executa diariamente às 23:59
Período de retenção: 30 dias após desativação
Ao deletar um perfil, os dados associados a ele são automaticamente removidos.
Logs de auditoria para DELETE não possuem `profile_id`
O campo `isDeactivated` foi renomeado para `deactivated` por causa de um bug de mapeamento do MapStruct com Lombok.
Evento `PROFILE_DELETION_SCHEDULED` é publicado no RabbitMQ quando o perfil é desativado.

Váriaveis de ambiente necessárias:
```
KEYCLOAK_SERVER_URL
KEYCLOAK_ADMIN_USER
KEYCLOAK_ADMIN_PASSWORD
KEYCLOAK_ADMIN_CLIENT_ID=admin-cli
KEYCLOAK_ADMIN_CLIENT_SECRET
```
### Endpoints
**PATCH** /api/v1/profiles/me/deactivate 
**PATCH** /api/v1/profiles/me/reactivate 

## Testes

### Antes de desativar
 
<img width="1621" height="416" alt="Captura de tela 2026-02-02 151734" src="https://github.com/user-attachments/assets/b37e34d2-3a23-4ef1-8e3f-749435eae20f" />
<img width="744" height="454" alt="Captura de tela 2026-02-02 151458" src="https://github.com/user-attachments/assets/a425d45c-3c20-4cc0-acfa-96eba7063f01" />
<img width="765" height="452" alt="Captura de tela 2026-02-02 151510" src="https://github.com/user-attachments/assets/4583952a-b271-47e6-86e9-ebc98fba2606" />
<img width="764" height="458" alt="Captura de tela 2026-02-02 151522" src="https://github.com/user-attachments/assets/8689e98a-d2b1-4b69-beb1-4b7c79865166" />
<img width="388" height="136" alt="Captura de tela 2026-02-02 151639" src="https://github.com/user-attachments/assets/0f638a4f-26a8-4c32-bee9-e7b09977f3d9" />

### Depois
<img width="415" height="153" alt="Captura de tela 2026-02-02 151749" src="https://github.com/user-attachments/assets/c051ef96-dd4e-467b-b2af-c353747b880d" />
<img width="569" height="105" alt="Captura de tela 2026-02-02 151753" src="https://github.com/user-attachments/assets/321c4049-f25a-4bd9-be53-d6ed8e770c35" />
<img width="1375" height="771" alt="Captura de tela 2026-02-02 151904" src="https://github.com/user-attachments/assets/384482e9-9ad1-4f4e-bdf1-0faf49344874" />
<img width="1498" height="611" alt="Captura de tela 2026-02-02 152029" src="https://github.com/user-attachments/assets/d1251ff7-9cde-44e2-b40c-5ac28fff249f" />
<img width="720" height="236" alt="image" src="https://github.com/user-attachments/assets/2fc17241-64e3-4ae0-b63c-e77b4b6995b4" />
<img width="742" height="243" alt="image" src="https://github.com/user-attachments/assets/694be00c-c2c2-4dcc-bb00-eae2c91e5e47" />
<img width="740" height="213" alt="image" src="https://github.com/user-attachments/assets/45336e2c-e9ac-446a-9c6c-13c67ca7602d" />
<img width="873" height="94" alt="image" src="https://github.com/user-attachments/assets/cc889180-a55b-4a32-b2f9-4d68196f2795" />

Resolves #32 #33 #34 